### PR TITLE
fix: tweak dependency tree to use correct react types

### DIFF
--- a/packages/react-material-ui/package.json
+++ b/packages/react-material-ui/package.json
@@ -12,8 +12,17 @@
   ],
   "peerDependencies": {
     "@concepta/react-data-provider": "^1.0.0-alpha.5",
+    "@types/react": "^18.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@emotion/react": "^11.10.4",
@@ -30,10 +39,8 @@
     "next": "^13.4.19"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.198"
-  },
-  "resolutions": {
-    "@types/react": "18.2.0",
-    "@types/react-dom": "18.2.0"
+    "@types/lodash": "^4.14.198",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
### About

This PR updates the package.json to not force any types version. When we define a resolution we're telling that we'd want to use that specific version. The problem with this approach is that the project that implements rockets-react might have a completely different version of the types and we'd be installing two different versions of the types, giving type conflicts and typescript errors.

We're heavily touching on material ui, and this part of rockets-react is event called react-material-ui so it's a good practice to follow their standard, check this reference: 
https://github.com/mui/material-ui/blob/master/packages/mui-lab/package.json