### PR TITLE
feat: add table small tweaks

### DIFF
--- a/packages/react-material-ui/src/components/Table/Table.tsx
+++ b/packages/react-material-ui/src/components/Table/Table.tsx
@@ -34,14 +34,14 @@ export type HeadersProps = {
 
 export type CustomTableCell = {
   component?: ReactNode;
-  value?: string;
+  value?: string | undefined;
   title?: string;
   sortableValue?: string | number;
 };
 
 export type RowsProps = {
   id: string;
-  [key: string]: string | number | CustomTableCell;
+  [key: string]: string | number | CustomTableCell | undefined;
 };
 
 export type SelectedRows = {
@@ -232,28 +232,32 @@ const TableComponent: FC<TableProps> = ({
   const emptyRows =
     _page - 1 > 0 ? Math.max(0, _page * _rowsPerPage - rows?.length) : 0;
 
-  const getCellData = (cell: CustomTableCell | string | number) => {
-    if (typeof cell === 'number' || typeof cell === 'string') {
+  const getCellData = (cell: CustomTableCell | string | number | undefined) => {
+    if (
+      typeof cell === 'number' ||
+      typeof cell === 'string' ||
+      typeof cell === 'undefined'
+    ) {
       return (
         <Text fontSize={14} fontWeight={400} color="text.primary">
-          {cell}
+          {cell ?? ''}
         </Text>
       );
     }
 
-    if ('value' in cell) {
-      if ('title' in cell) {
-        return (
-          <Tooltip title={cell.title}>
-            <span>{cell.value}</span>
-          </Tooltip>
-        );
-      }
-
+    if (!('title' in cell)) {
       return (
         <Text fontSize={14} fontWeight={400} color="text.primary">
-          {cell.value}
+          {cell.value ?? ''}
         </Text>
+      );
+    }
+
+    if ('title' in cell) {
+      return (
+        <Tooltip title={cell.title}>
+          <span>{cell.value ?? ''}</span>
+        </Tooltip>
       );
     }
 

--- a/packages/react-material-ui/src/components/Table/Table.tsx
+++ b/packages/react-material-ui/src/components/Table/Table.tsx
@@ -20,18 +20,23 @@ import TableHeaders from './TableHeaders';
 import TableOptions from './TableOptions';
 import useTheme from '@mui/material/styles/useTheme';
 import { TableProps as TableInputProps } from './useTable';
+import { Tooltip } from '@mui/material';
 
 export type HeadersProps = {
   disablePadding?: boolean;
   id: string;
   label: string;
+  width?: number;
   numeric?: boolean;
   textAlign?: 'left' | 'center' | 'right';
+  sortable?: boolean;
 };
 
 export type CustomTableCell = {
+  component?: ReactNode;
+  value?: string;
+  title?: string;
   sortableValue?: string | number;
-  component: ReactNode;
 };
 
 export type RowsProps = {
@@ -71,6 +76,7 @@ export type TableProps = {
   total?: TableInputProps['total'];
   page?: TableInputProps['page'];
   pageCount?: TableInputProps['pageCount'];
+  rowsPerPageOptions?: TablePaginationProps['rowsPerPageOptions'];
   rowsPerPage?: TableInputProps['rowsPerPage'];
   order?: Order;
   orderBy?: TableInputProps['orderBy'];
@@ -87,16 +93,19 @@ export type TableProps = {
   customRowOptions?:
     | SimpleOptionButton[]
     | (({ row, close }: CustomRowOptionsProps) => ReactNode);
+  noPagination?: boolean;
   variant?: TableStylesProps['variant'];
   paginationVariant?: 'default' | 'numbers';
   toggleDirection?: 'horizontal' | 'vertical';
   hover?: boolean;
+  tableProps?: MuiTableProps;
   tableStyles?: MuiTableProps['sx'];
   tableHeaderRowStyles?: MuiTableProps['sx'];
   tableHeaderCellStyles?: MuiTableProps['sx'];
   tableRowStyles?: MuiTableProps['sx'];
   tableCellStyles?: MuiTableProps['sx'];
   paginationStyles?: TablePaginationProps['sx'] | PaginationProps['sx'];
+  emptyMessage?: string | ReactNode;
 };
 
 const TableComponent: FC<TableProps> = ({
@@ -107,6 +116,7 @@ const TableComponent: FC<TableProps> = ({
   total,
   page,
   pageCount,
+  rowsPerPageOptions = [5, 10, 25],
   rowsPerPage,
   order,
   orderBy,
@@ -120,15 +130,18 @@ const TableComponent: FC<TableProps> = ({
   customToolbarActionButtons,
   customRowOptions,
   variant = 'contained',
+  noPagination = false,
   paginationVariant = 'default',
   toggleDirection = 'horizontal',
   hover = true,
+  tableProps,
   tableStyles,
   tableHeaderRowStyles,
   tableHeaderCellStyles,
   tableRowStyles,
   tableCellStyles,
   paginationStyles,
+  emptyMessage = 'No records found',
 }) => {
   const theme = useTheme();
 
@@ -228,7 +241,23 @@ const TableComponent: FC<TableProps> = ({
       );
     }
 
-    if ('component' in cell && typeof cell.sortableValue !== 'undefined') {
+    if ('value' in cell) {
+      if ('title' in cell) {
+        return (
+          <Tooltip title={cell.title}>
+            <span>{cell.value}</span>
+          </Tooltip>
+        );
+      }
+
+      return (
+        <Text fontSize={14} fontWeight={400} color="text.primary">
+          {cell.value}
+        </Text>
+      );
+    }
+
+    if ('component' in cell) {
       return cell.component;
     }
   };
@@ -274,7 +303,14 @@ const TableComponent: FC<TableProps> = ({
         <TableContainer {...tableContainerProps}>
           <Table
             stickyHeader
-            sx={{ minWidth: 750 }}
+            sx={[
+              {
+                minWidth: 750,
+              },
+              ...(Array.isArray(tableProps.sx)
+                ? tableProps.sx
+                : [tableProps.sx]),
+            ]}
             aria-labelledby="tableTitle"
             size="medium"
             variant={variant}
@@ -283,6 +319,7 @@ const TableComponent: FC<TableProps> = ({
             tableHeaderCellStyles={tableHeaderCellStyles}
             tableRowStyles={tableRowStyles}
             tableCellStyles={tableCellStyles}
+            {...tableProps}
           >
             <TableHeaders
               numSelected={selected.length}
@@ -296,6 +333,24 @@ const TableComponent: FC<TableProps> = ({
               hasOptions={hasOptions}
             />
             <TableBody>
+              {!total && !rows?.length && (
+                <>
+                  {typeof emptyMessage === 'string' ? (
+                    <TableRow>
+                      <TableCell
+                        sx={{
+                          textAlign: 'center',
+                        }}
+                        colSpan={headers.length}
+                      >
+                        {emptyMessage}
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    emptyMessage
+                  )}
+                </>
+              )}
               {typeof page === 'number' &&
                 rows?.map((row, index) => {
                   const isItemSelected = isSelected(row.id);
@@ -339,6 +394,7 @@ const TableComponent: FC<TableProps> = ({
                   );
                 })}
               {typeof page === 'undefined' &&
+                !noPagination &&
                 rows
                   .slice(
                     (_page - 1) * _rowsPerPage,
@@ -398,46 +454,50 @@ const TableComponent: FC<TableProps> = ({
             </TableBody>
           </Table>
         </TableContainer>
-        {paginationVariant === 'default' && (
-          <TablePagination
-            rowsPerPageOptions={[5, 10, 25]}
-            component="div"
-            count={total || rows?.length || 0}
-            rowsPerPage={rowsPerPage || _rowsPerPage}
-            page={_page ? _page - 1 : 0}
-            onPageChange={(event: unknown, page: number) =>
-              handleChangePage(event, page + 1)
-            }
-            onRowsPerPageChange={handleChangeRowsPerPage}
-            sx={{
-              ...(variant === 'outlined' && {
-                backgroundColor:
-                  theme.palette.mode === 'light'
-                    ? theme.palette.grey[100]
-                    : theme.palette.grey[800],
-                border: `solid 1px #e5e7eb`,
-                borderTop: 'none',
-                borderBottomLeftRadius: '10px',
-                borderBottomRightRadius: '10px',
-                borderLeftStyle: 'solid',
-                borderRightStyle: 'solid',
-              }),
-            }}
-          />
-        )}
-        {paginationVariant === 'numbers' && (
-          <Box display="flex" justifyContent="center">
-            <Pagination
-              count={
-                pageCount ||
-                (rows?.length && Math.floor(rows?.length / 5) + 1) ||
-                0
-              }
-              onChange={handleChangePage}
-              page={_page}
-              sx={paginationStyles}
-            />
-          </Box>
+        {!noPagination && (
+          <>
+            {paginationVariant === 'default' && (
+              <TablePagination
+                rowsPerPageOptions={rowsPerPageOptions}
+                component="div"
+                count={total || rows?.length || 0}
+                rowsPerPage={rowsPerPage || _rowsPerPage}
+                page={_page ? _page - 1 : 0}
+                onPageChange={(event: unknown, page: number) =>
+                  handleChangePage(event, page + 1)
+                }
+                onRowsPerPageChange={handleChangeRowsPerPage}
+                sx={{
+                  ...(variant === 'outlined' && {
+                    backgroundColor:
+                      theme.palette.mode === 'light'
+                        ? theme.palette.grey[100]
+                        : theme.palette.grey[800],
+                    border: `solid 1px #e5e7eb`,
+                    borderTop: 'none',
+                    borderBottomLeftRadius: '10px',
+                    borderBottomRightRadius: '10px',
+                    borderLeftStyle: 'solid',
+                    borderRightStyle: 'solid',
+                  }),
+                }}
+              />
+            )}
+            {paginationVariant === 'numbers' && (
+              <Box display="flex" justifyContent="center">
+                <Pagination
+                  count={
+                    pageCount ||
+                    (rows?.length && Math.floor(rows?.length / 5) + 1) ||
+                    0
+                  }
+                  onChange={handleChangePage}
+                  page={_page}
+                  sx={paginationStyles}
+                />
+              </Box>
+            )}
+          </>
         )}
       </>
     </Box>

--- a/packages/react-material-ui/src/components/Table/TableHeaders.tsx
+++ b/packages/react-material-ui/src/components/Table/TableHeaders.tsx
@@ -54,27 +54,38 @@ const TableHeaders: FC<Props> = (props) => {
           </TableCell>
         )}
 
-        {headers.map((headCell) => (
-          <TableCell
-            key={headCell.id}
-            align={headCell?.textAlign || headCell.numeric ? 'right' : 'left'}
-            padding={headCell.disablePadding ? 'none' : 'normal'}
-            sortDirection={orderBy === headCell.id ? order : false}
-          >
-            <TableSortLabel
-              active={orderBy === headCell.id}
-              direction={orderBy === headCell.id ? order : 'asc'}
-              onClick={createSortHandler(headCell.id)}
+        {headers.map((headCell) => {
+          const isHeaderSortable = headCell.sortable ?? true;
+
+          return (
+            <TableCell
+              key={headCell.id}
+              width={headCell.width}
+              align={headCell?.textAlign || headCell.numeric ? 'right' : 'left'}
+              padding={headCell.disablePadding ? 'none' : 'normal'}
+              sortDirection={orderBy === headCell.id ? order : false}
             >
-              {headCell.label}
-              {orderBy === headCell.id ? (
-                <Box component="span" sx={visuallyHidden}>
-                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                </Box>
-              ) : null}
-            </TableSortLabel>
-          </TableCell>
-        ))}
+              {isHeaderSortable ? (
+                <TableSortLabel
+                  active={orderBy === headCell.id}
+                  direction={orderBy === headCell.id ? order : 'asc'}
+                  onClick={createSortHandler(headCell.id)}
+                >
+                  {headCell.label}
+                  {orderBy === headCell.id ? (
+                    <Box component="span" sx={visuallyHidden}>
+                      {order === 'desc'
+                        ? 'sorted descending'
+                        : 'sorted ascending'}
+                    </Box>
+                  ) : null}
+                </TableSortLabel>
+              ) : (
+                <>{headCell.label}</>
+              )}
+            </TableCell>
+          );
+        })}
         {hasOptions && <TableCell key="options" align="left" padding="none" />}
       </TableRow>
     </TableHead>


### PR DESCRIPTION
## About

This PR aims to add the following tweaks to the Table component in order to make it more flexible.

- Add empty state display
- Table Custom Row
   - Make sortableValue optional
   - Allow sortableValue to be a number or string
- Prop to remove pagination and show full list
- Add title (popup info) to cell
- Header styles

We're also updating the following in the usetable hook:

- Add DataProviderRequest (onError, onSuccess, onFinish) props
- Add ability to fetch data without pagination

## Examples

### Empty state

```
<Table
      emptyMessage="No users found!" // Defaults to "No records found" based on total && rows.length
      ...
/>
```

### No pagination

```
<Table
      noPagination
      ...
/>

const { data, tableProps } = useTable('user', {
    noPagination: true
 });
```

### Table Custom Row (sortable, sortableValue)

```
const headers: HeadersProps[] = [
...
  {
    id: 'name',
    label: 'Name',
    sortable: false, // new prop to disable sort in the header
  }
...
```

### Add title to cell

```
const rows: RowsProps[] => {
   ...
   role: {
      value: 'Member',
      title: 'This is the title', // It will render upon cell hover
   }
   ...
}

```

This would render the same as above but without the title on hover:

```
const rows: RowsProps[] => {
   ...
   role: 'Member'
   ...
}
```
