### PR TITLE
feat: add unauthorized handler to DataProvider and expose refreshToken

### DIFF
--- a/packages/react-auth-provider/src/index.tsx
+++ b/packages/react-auth-provider/src/index.tsx
@@ -63,6 +63,7 @@ const AuthProvider: React.FC<
 
   const doLogout = async () => {
     localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
   };
 
   return (

--- a/packages/react-auth-provider/src/index.tsx
+++ b/packages/react-auth-provider/src/index.tsx
@@ -47,6 +47,7 @@ const AuthProvider: React.FC<
         setAccessToken(data.accessToken);
         setRefreshToken(data.refreshToken);
         localStorage.setItem('accessToken', data.accessToken);
+        localStorage.setItem('refreshToken', data.refreshToken);
         onSuccess?.(data.accessToken);
       }
     },

--- a/packages/react-data-provider/src/ClientProvider.tsx
+++ b/packages/react-data-provider/src/ClientProvider.tsx
@@ -9,18 +9,27 @@ import React, {
 
 export type ClientContextType = {
   baseUrl: string;
+  onRefreshTokenError: () => void;
 };
 
-export const ClientContext = createContext<ClientContextType>({ baseUrl: '' });
+export const ClientContext = createContext<ClientContextType>({
+  baseUrl: '',
+  onRefreshTokenError: () => ({}),
+});
 
 export const useClient = () => useContext<ClientContextType>(ClientContext);
 
 type Props = {
   baseUrl?: string;
+  onRefreshTokenError: () => void;
   children: ReactNode;
 };
 
-const ClientProvider: FC<Props> = ({ baseUrl: outerBaseUrl, children }) => {
+const ClientProvider: FC<Props> = ({
+  baseUrl: outerBaseUrl,
+  onRefreshTokenError,
+  children,
+}) => {
   const [baseUrl, setBaseUrl] = useState<string>();
 
   useEffect(() => {
@@ -30,7 +39,7 @@ const ClientProvider: FC<Props> = ({ baseUrl: outerBaseUrl, children }) => {
   }, [outerBaseUrl]);
 
   return (
-    <ClientContext.Provider value={{ baseUrl }}>
+    <ClientContext.Provider value={{ baseUrl, onRefreshTokenError }}>
       {children}
     </ClientContext.Provider>
   );

--- a/packages/react-data-provider/src/ClientProvider.tsx
+++ b/packages/react-data-provider/src/ClientProvider.tsx
@@ -6,10 +6,11 @@ import React, {
   useState,
   useContext,
 } from 'react';
+import { HttpError } from './interfaces';
 
 export type ClientContextType = {
   baseUrl: string;
-  onRefreshTokenError: () => void;
+  onRefreshTokenError: (error?: HttpError) => void;
 };
 
 export const ClientContext = createContext<ClientContextType>({
@@ -21,7 +22,7 @@ export const useClient = () => useContext<ClientContextType>(ClientContext);
 
 type Props = {
   baseUrl?: string;
-  onRefreshTokenError: () => void;
+  onRefreshTokenError: (error?: HttpError) => void;
   children: ReactNode;
 };
 

--- a/packages/react-data-provider/src/axiosClient.ts
+++ b/packages/react-data-provider/src/axiosClient.ts
@@ -57,19 +57,21 @@ const axiosClient: HttpClient = {
     }
 
     axiosInstance.interceptors.request.use(
-      async (config): Promise<AxiosRequestConfig> => {
+      async (config) => {
         if (
           config.url &&
           defaultConfigs.skipAuthUris.findIndex((uri) =>
             config?.url?.includes(uri),
-          ) == -1
+          ) === -1
         ) {
           const accessToken = middlewares?.getAccessToken?.();
           if (config.headers) {
             config.headers.Authorization = `Bearer ${accessToken}`;
           }
+
+          return Promise.resolve(config);
         }
-        return config;
+        return Promise.resolve(config);
       },
       async (error): Promise<AxiosRequestConfig> => Promise.reject(error),
     );
@@ -79,17 +81,32 @@ const axiosClient: HttpClient = {
       async (error) => {
         const config = error?.config;
 
-        if (error?.response?.status === 401) {
-          const response = await middlewares.getNewToken();
+        if (
+          config.url &&
+          defaultConfigs.skipAuthUris.findIndex((uri) =>
+            config?.url?.includes(uri),
+          ) === -1
+        ) {
+          if (error?.response?.status === 401 && !config?._sent) {
+            config._sent = true;
 
-          if ('accessToken' in response && 'refreshToken' in response) {
-            if (config.headers) {
-              config.headers.Authorization = `Bearer ${response.accessToken}`;
+            const response = await middlewares.getNewToken();
+
+            if (
+              response &&
+              'accessToken' in response &&
+              'refreshToken' in response
+            ) {
+              if (config.headers) {
+                config.headers.Authorization = `Bearer ${response.accessToken}`;
+              }
+
+              return axiosInstance(config);
             }
-            return axiosInstance(config);
+
+            return Promise.reject(error);
           }
         }
-
         return Promise.reject(error);
       },
     );

--- a/packages/react-data-provider/src/interfaces/index.ts
+++ b/packages/react-data-provider/src/interfaces/index.ts
@@ -33,13 +33,18 @@ export interface HttpError {
   message: string;
 }
 
-export interface HttpMidlewares {
+export interface Token {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface HttpMiddlewares {
   getAccessToken?(): void;
-  getNewToken?(): void;
+  getNewToken?(): Promise<Token | HttpError | null>;
 }
 
 export interface HttpClient {
-  applyMiddleware({ getAccessToken, getNewToken }: HttpMidlewares): void;
+  applyMiddleware({ getAccessToken, getNewToken }: HttpMiddlewares): void;
   defaultConfig(config: HttpBaseConfigs): void;
   executeRequest(params: RequestParams): Promise<HttpResponse>;
 }

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -47,17 +47,17 @@ const useDataProvider = () => {
               localStorage.setItem('refreshToken', res.refreshToken);
             }
 
-            resolve(res);
+            return resolve(res);
           })
           .catch(async (error) => {
             localStorage.removeItem('accessToken');
             localStorage.removeItem('refreshToken');
-            onRefreshTokenError();
-            reject(error);
+            onRefreshTokenError(error);
+            return reject(error);
           });
-      } catch (err) {
-        onRefreshTokenError();
-        return reject(err);
+      } catch (error) {
+        onRefreshTokenError(error);
+        return reject(error);
       }
     });
   };
@@ -81,14 +81,7 @@ const useDataProvider = () => {
       }
     },
     getNewToken: async () => {
-      const refreshToken = localStorage.getItem('refreshToken');
-
-      if (refreshToken) {
-        return await refreshAccessToken();
-      } else {
-        onRefreshTokenError();
-        return null;
-      }
+      return await refreshAccessToken();
     },
   });
 

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -9,11 +9,12 @@ import {
   PutRequestOptions,
   PatchRequestOptions,
   DeleteRequestOptions,
+  Token,
 } from './interfaces';
 import { useClient } from './ClientProvider';
 
 const useDataProvider = () => {
-  const { baseUrl } = useClient();
+  const { baseUrl, onRefreshTokenError } = useClient();
   const envBaseUrl = process.env.NEXT_PUBLIC_API_URL;
 
   const _baseUrl = baseUrl || envBaseUrl;
@@ -21,6 +22,45 @@ const useDataProvider = () => {
   //TODO
   //let user inject any http instance that match the HttpClient interface requirements
   const client: HttpClient = axiosClient;
+
+  /**
+   * Asynchronously refreshes an access token using a stored refresh token.
+   * @returns A promise that resolves with the response from the token refresh request or rejects with an error.
+   * @throws If an exception occurs while refreshing the token.
+   */
+  const refreshAccessToken = async (): Promise<Token | HttpError> => {
+    return new Promise((resolve, reject) => {
+      try {
+        const refreshToken = localStorage.getItem('refreshToken');
+
+        const body = {
+          refreshToken,
+        };
+
+        return post({
+          uri: '/token/refresh',
+          body,
+        })
+          .then(async (res) => {
+            if (res?.accessToken && res?.refreshToken) {
+              localStorage.setItem('accessToken', res.accessToken);
+              localStorage.setItem('refreshToken', res.refreshToken);
+            }
+
+            resolve(res);
+          })
+          .catch(async (error) => {
+            localStorage.removeItem('accessToken');
+            localStorage.removeItem('refreshToken');
+            onRefreshTokenError();
+            reject(error);
+          });
+      } catch (err) {
+        onRefreshTokenError();
+        return reject(err);
+      }
+    });
+  };
 
   client.defaultConfig({
     baseURL: _baseUrl,
@@ -40,14 +80,15 @@ const useDataProvider = () => {
         //redirect to login
       }
     },
-    getNewToken: () => {
-      //TODO
-      // const makeRequest = localStorage.getItem("refresh_token");
-      // if(refreshToken){
-      //   return refreshToken;
-      // }else{
-      //   //redirect to login
-      // }
+    getNewToken: async () => {
+      const refreshToken = localStorage.getItem('refreshToken');
+
+      if (refreshToken) {
+        return await refreshAccessToken();
+      } else {
+        onRefreshTokenError();
+        return null;
+      }
     },
   });
 

--- a/packages/react-material-ui/src/components/Table/useTable.ts
+++ b/packages/react-material-ui/src/components/Table/useTable.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import isEqual from 'lodash/isEqual';
 import { Order } from './Table';
-import { DataProviderRequestProps } from '@concepta/react-data-provider/dist/interfaces';
+import { DataProviderRequestOptions } from '@concepta/react-data-provider/dist/interfaces';
 
 type BasicType = string | number | boolean;
 
@@ -14,7 +14,7 @@ interface Options {
   order?: Order;
   simpleFilter?: Record<string, BasicType | BasicType[]>;
   search?: string;
-  callbacks?: DataProviderRequestProps;
+  callbacks?: DataProviderRequestOptions;
   noPagination?: boolean;
 }
 


### PR DESCRIPTION
### About 

This PR adds the ability to refresh the access token using refreshToken and it fails it executes a callback passed to ClientProvider at the same time that it removes both accessToken and refreshToken from localStorage.
It also adds the refreshToken to the localStorage.