### PR TITLE
feat: add table skeleton loading

### DIFF
--- a/packages/react-material-ui/src/components/Table/TableBody/TableBodyRows.tsx
+++ b/packages/react-material-ui/src/components/Table/TableBody/TableBodyRows.tsx
@@ -6,6 +6,7 @@ import { Order, RenderRowFunction, RowProps } from '../types';
 import { useTableRoot } from '../hooks/useTableRoot';
 import { TableBodyRow } from './TableBodyRow';
 import { TableBodyCells } from './TableBodyCells';
+import { TableRowSkeleton } from '../TableRowSkeleton';
 
 /**
  * Returns a paginated and sorted subset of rows based on the current page, rowsPerPage, order, and orderBy.
@@ -62,6 +63,7 @@ const renderTableRows = (
 
 type TableBodyRowProps = {
   renderRow?: RenderRowFunction;
+  isLoading?: boolean;
 };
 
 /**
@@ -70,9 +72,16 @@ type TableBodyRowProps = {
  * @param {TableBodyRowProps} props - The props for the TableBodyRows component.
  * @returns An array of React elements representing the table body rows.
  */
-export const TableBodyRows = ({ renderRow }: TableBodyRowProps) => {
+export const TableBodyRows = ({
+  renderRow,
+  isLoading = false,
+}: TableBodyRowProps) => {
   const { rows, tableQuery, isControlled } = useTableRoot();
   const { page, rowsPerPage, order, orderBy } = tableQuery;
+
+  if (isLoading) {
+    return <TableRowSkeleton />;
+  }
 
   if (isControlled) {
     return rows.map((row, index) => {

--- a/packages/react-material-ui/src/components/Table/TableCellSkeleton.tsx
+++ b/packages/react-material-ui/src/components/Table/TableCellSkeleton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { Skeleton, TableCell } from '@mui/material';
+import { useTableRoot } from './hooks/useTableRoot';
+
+/**
+ * TableCellSkeleton component represents skeleton cells in a table row.
+ *
+ * @returns A React element representing the table cell skeleton.
+ */
+export const TableCellSkeleton = () => {
+  const { headers } = useTableRoot();
+
+  return (
+    <>
+      {headers.map((header) => (
+        <TableCell key={header.id}>
+          <Skeleton height={32} width={header.width} />
+        </TableCell>
+      ))}
+    </>
+  );
+};

--- a/packages/react-material-ui/src/components/Table/TableRowSkeleton.tsx
+++ b/packages/react-material-ui/src/components/Table/TableRowSkeleton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import { TableRow } from '@mui/material';
+
+import { TableCellSkeleton } from './TableCellSkeleton';
+import { useTableRoot } from './hooks/useTableRoot';
+
+/**
+ * TableRowSkeleton component represents a row of skeleton cells in a table.
+ *
+ * @returns A React element representing the table row skeleton.
+ */
+export const TableRowSkeleton = () => {
+  const { tableQuery } = useTableRoot();
+
+  const rowsToRender = Array.from(
+    { length: tableQuery.rowsPerPage },
+    (_, index) => index + 1,
+  );
+
+  return (
+    <>
+      {rowsToRender.map((item) => (
+        <TableRow key={item}>
+          <TableCellSkeleton />
+        </TableRow>
+      ))}
+    </>
+  );
+};

--- a/packages/react-material-ui/src/components/Table/index.ts
+++ b/packages/react-material-ui/src/components/Table/index.ts
@@ -13,6 +13,8 @@ import { TableBodyRow } from './TableBody/TableBodyRow';
 import { TableBodyRows } from './TableBody/TableBodyRows';
 import { TableRoot } from './TableRoot';
 import { TableHeaderCell } from './TableHeader/TableHeaderCell';
+import { TableRowSkeleton } from './TableRowSkeleton';
+import { TableCellSkeleton } from './TableCellSkeleton';
 
 const TableComponent = {
   Table,
@@ -28,6 +30,8 @@ const TableComponent = {
   HeaderCheckbox: TableHeaderCheckbox,
   HeaderOption: TableHeaderOption,
   Root: TableRoot,
+  CellSkeleton: TableCellSkeleton,
+  RowSkeleton: TableRowSkeleton,
 };
 
 export default TableComponent;


### PR DESCRIPTION
### About

This PR adds table skeleton loading as default for Table.BodyRows loading state.
It also fixes a minor issue on simpleFilter update.


### Usage Example

```
   <Table.BodyRows isLoading={isLoading} />
```