### PR TITLE
feat: add autocomplete widget

### DIFF
--- a/packages/react-material-ui/src/components/FormFieldSkeleton/index.tsx
+++ b/packages/react-material-ui/src/components/FormFieldSkeleton/index.tsx
@@ -1,4 +1,5 @@
-import React, { Box, Skeleton, useTheme } from '@mui/material';
+import React from 'react';
+import { Box, Skeleton, useTheme } from '@mui/material';
 
 type FormFieldSkeletonProps = {
   hideLabel?: boolean;

--- a/packages/react-material-ui/src/components/FormFieldSkeleton/index.tsx
+++ b/packages/react-material-ui/src/components/FormFieldSkeleton/index.tsx
@@ -1,0 +1,26 @@
+import React, { Box, Skeleton, useTheme } from '@mui/material';
+
+type FormFieldSkeletonProps = {
+  hideLabel?: boolean;
+};
+
+const FormFieldSkeleton = ({ hideLabel }: FormFieldSkeletonProps) => {
+  const theme = useTheme();
+
+  return (
+    <Box width="100%">
+      {!hideLabel && (
+        <Skeleton
+          variant="text"
+          width={80}
+          sx={{
+            fontSize: theme.typography.body1.fontSize,
+          }}
+        />
+      )}
+      <Skeleton variant="rounded" height={42} width="100%" />
+    </Box>
+  );
+};
+
+export default FormFieldSkeleton;

--- a/packages/react-material-ui/src/components/TextField/TextField.tsx
+++ b/packages/react-material-ui/src/components/TextField/TextField.tsx
@@ -38,6 +38,7 @@ const TextField: FC<TextFieldProps & Props> = (props) => {
     options,
     containerProps,
     labelProps,
+    ...rest
   } = props;
 
   const [showPassword, setShowPassword] = useState(false);
@@ -66,7 +67,7 @@ const TextField: FC<TextFieldProps & Props> = (props) => {
       )}
 
       <MuiTextField
-        {...props}
+        {...rest}
         sx={[
           {
             marginTop: 0.5,
@@ -95,6 +96,7 @@ const TextField: FC<TextFieldProps & Props> = (props) => {
               </InputAdornment>
             ),
           }),
+          ...props.InputProps,
         }}
       />
     </Box>

--- a/packages/react-material-ui/src/index.ts
+++ b/packages/react-material-ui/src/index.ts
@@ -37,4 +37,7 @@ export { default as TextField } from './components/TextField';
 export { default as SimpleForm } from './components/SimpleForm';
 export { default as SchemaForm } from './components/SchemaForm';
 
+import FormFieldSkeleton from './components/FormFieldSkeleton';
+export { FormFieldSkeleton };
+
 export * from './utils';

--- a/packages/react-material-ui/src/styles/CustomWidgets/CustomAutocompleteWidget.tsx
+++ b/packages/react-material-ui/src/styles/CustomWidgets/CustomAutocompleteWidget.tsx
@@ -77,10 +77,12 @@ export default function CustomAutocompleteWidget<
   const resource = uiSchema?.['ui:resource'];
   const resourceLabel = uiSchema?.['ui:resourceLabel'];
   const resourceValue = uiSchema?.['ui:resourceValue'];
+  const queryParams = uiSchema?.['ui:queryParams'];
 
   const getResource = () => {
     return get({
       uri: `/${resource}`,
+      queryParams,
     });
   };
   const { execute, data, isPending } = useQuery(getResource, false);

--- a/packages/react-material-ui/src/styles/CustomWidgets/CustomAutocompleteWidget.tsx
+++ b/packages/react-material-ui/src/styles/CustomWidgets/CustomAutocompleteWidget.tsx
@@ -1,0 +1,161 @@
+import React, { FocusEvent, SyntheticEvent, useEffect } from 'react';
+import { TextFieldProps } from '@mui/material/TextField';
+import {
+  ariaDescribedByIds,
+  enumOptionsValueForIndex,
+  labelValue,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from '@rjsf/utils';
+import { Autocomplete } from '@mui/material';
+import TextField from '../../components/TextField';
+import useDataProvider, { useQuery } from '@concepta/react-data-provider';
+import FormFieldSkeleton from '../../components/FormFieldSkeleton';
+
+/** The `SelectWidget` is a widget for rendering dropdowns.
+ *  It is typically used with string properties constrained with enum options.
+ *
+ * @param props - The `WidgetProps` for this component
+ * @returns A React JSX element representing the autocomplete.
+ */
+export default function CustomAutocompleteWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>({
+  schema,
+  id,
+  name, // remove this from textFieldProps
+  options,
+  label,
+  hideLabel,
+  required,
+  disabled,
+  placeholder,
+  readonly,
+  value,
+  multiple,
+  autofocus,
+  onChange,
+  onBlur,
+  onFocus,
+  rawErrors = [],
+  size,
+  registry,
+  uiSchema,
+  hideError,
+  formContext,
+  ...textFieldProps
+}: WidgetProps<T, S, F>) {
+  const { get } = useDataProvider();
+
+  const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
+
+  const resource = uiSchema?.['ui:resource'];
+  const resourceLabel = uiSchema?.['ui:resourceLabel'];
+  const resourceValue = uiSchema?.['ui:resourceValue'];
+
+  multiple = typeof multiple === 'undefined' ? false : !!multiple;
+
+  const getResource = () => {
+    return get({
+      uri: `/${resource}`,
+    });
+  };
+
+  const { execute, data, isPending } = useQuery(getResource, false);
+
+  const resourceOptions = data?.map((resource) => ({
+    value: resource[resourceValue ?? 'id'],
+    label: resource[resourceLabel ?? 'name'],
+  }));
+
+  const availableOptions = resource ? resourceOptions : enumOptions;
+
+  const controlledValue = availableOptions?.find(
+    (option) => option.value === value,
+  );
+
+  const emptyValue = multiple ? [] : '';
+  const isEmpty =
+    typeof value === 'undefined' ||
+    (multiple && value.length < 1) ||
+    (!multiple && value === emptyValue);
+
+  const _onChange = (
+    _: SyntheticEvent<Element, Event>,
+    newValue: { value: string; label: string },
+  ) => {
+    if (!newValue) return onChange(optEmptyVal);
+
+    onChange(newValue?.value);
+  };
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onBlur(
+      id,
+      enumOptionsValueForIndex<S>(value, availableOptions, optEmptyVal),
+    );
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(
+      id,
+      enumOptionsValueForIndex<S>(value, availableOptions, optEmptyVal),
+    );
+
+  // TODO: Implement multiple select
+  /* const selectedIndexes = enumOptionsIndexForValue<S>(
+    value,
+    availableOptions,
+    multiple,
+  ); */
+
+  useEffect(() => {
+    if (resource) {
+      execute();
+    }
+  }, []);
+
+  // TODO: This has to be done in a more generic way
+  // e.g. BaseInputTemplate
+  if (isPending) {
+    return <FormFieldSkeleton />;
+  }
+
+  return (
+    <Autocomplete
+      key={controlledValue}
+      options={availableOptions ?? []}
+      isOptionEqualToValue={(option) => option.value === controlledValue}
+      getOptionLabel={(option) => option.label}
+      size={size ?? 'small'}
+      value={controlledValue}
+      onChange={_onChange}
+      onBlur={_onBlur}
+      onFocus={_onFocus}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          id={id}
+          name={id}
+          label={labelValue(label || undefined, hideLabel, false)}
+          required={required}
+          disabled={disabled || readonly}
+          autoFocus={autofocus}
+          placeholder={placeholder}
+          error={rawErrors.length > 0}
+          {...(textFieldProps as TextFieldProps)}
+          InputLabelProps={{
+            ...textFieldProps.InputLabelProps,
+            shrink: !isEmpty,
+          }}
+          SelectProps={{
+            ...textFieldProps.SelectProps,
+            multiple,
+          }}
+          aria-describedby={ariaDescribedByIds<T>(id)}
+        />
+      )}
+    />
+  );
+}

--- a/packages/react-material-ui/src/styles/CustomWidgets/index.ts
+++ b/packages/react-material-ui/src/styles/CustomWidgets/index.ts
@@ -7,3 +7,4 @@ export { default as CustomTextFieldWidget } from './CustomTextFieldWidget';
 export { default as CustomEmailFieldWidget } from './CustomEmailFieldWidget';
 export { default as CustomPasswordFieldWidget } from './CustomPasswordFieldWidget';
 export { default as CustomRadioWidget } from './CustomRadioWidget';
+export { default as CustomAutocompleteWidget } from './CustomAutocompleteWidget';


### PR DESCRIPTION
### About

This PR aims to add Autocomplete widget to be using within RSJF.

### Usage example

```
export const uiSchema: UiSchema = {
  country: {
    'ui:widget': CustomAutocompleteWidget,
    // this is optional, if not provided the request will not be made
   // and the values to the autocomplete must be provided in an enum fashion
   'ui:resource': '/countries',
   // this is optional, defaults to 'id' and 'name' respectively
   'ui:resourceLabel': 'label'
   'ui:resourceValue': 'mainId'
  },
};
```