### PR TITLE
feat: add search field component

### DIFF
--- a/packages/react-material-ui/src/components/SearchField/index.tsx
+++ b/packages/react-material-ui/src/components/SearchField/index.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React, { useState, ChangeEvent, useEffect, useMemo } from 'react';
+import MuiSearchIcon from '@mui/icons-material/Search';
+import debounce from 'lodash/debounce';
+import {
+  IconButton,
+  InputAdornment,
+  TextField,
+  TextFieldProps,
+} from '@mui/material';
+import { Clear } from '@mui/icons-material';
+
+const SearchIcon = () => (
+  <MuiSearchIcon
+    sx={{
+      color: 'grey.400',
+    }}
+  />
+);
+
+type SearchFieldProps = {
+  searchIconPlacement?: 'start' | 'end';
+  defaultValue?: string;
+  wait?: number;
+  onDebouncedSearchChange: (searchTerm: string) => void;
+} & TextFieldProps;
+
+const SearchField = ({
+  searchIconPlacement = 'end',
+  defaultValue = '',
+  wait = 500,
+  onDebouncedSearchChange,
+  ...props
+}: SearchFieldProps) => {
+  const [search, setSearch] = useState<string>(defaultValue);
+
+  const handleDebouncedSearch = useMemo(
+    () => debounce(onDebouncedSearchChange, wait),
+    [],
+  );
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) =>
+    setSearch(event.target.value);
+
+  useEffect(() => {
+    handleDebouncedSearch(search);
+  }, [search]);
+
+  return (
+    <TextField
+      placeholder="Search"
+      variant="outlined"
+      onChange={handleChange}
+      value={search}
+      InputProps={{
+        ...(searchIconPlacement === 'start' && {
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        }),
+        endAdornment: (
+          <InputAdornment position="end">
+            <IconButton
+              size="small"
+              sx={{
+                mr: 0.5,
+                visibility: search ? 'visible' : 'hidden',
+              }}
+              aria-label="clear search"
+              onClick={() => setSearch('')}
+            >
+              <Clear fontSize="small" />
+            </IconButton>
+            {searchIconPlacement === 'end' && <SearchIcon />}
+          </InputAdornment>
+        ),
+      }}
+      {...props}
+    />
+  );
+};
+
+export default SearchField;

--- a/packages/react-material-ui/src/components/Table/useTable.ts
+++ b/packages/react-material-ui/src/components/Table/useTable.ts
@@ -155,7 +155,8 @@ const useTable: UseTableProps = (resource, options) => {
       }
 
       const updatedSimpleFilter =
-        Object.keys(updatedState?.simpleFilter).length > 0
+        updatedState?.simpleFilter &&
+        Object.keys(updatedState.simpleFilter).length > 0
           ? updatedState.simpleFilter
           : undefined;
 

--- a/packages/react-material-ui/src/index.ts
+++ b/packages/react-material-ui/src/index.ts
@@ -34,6 +34,7 @@ export { Table };
 
 export { default as Text } from './components/Text';
 export { default as TextField } from './components/TextField';
+export { default as SearchField } from './components/SearchField';
 export { default as SimpleForm } from './components/SimpleForm';
 export { default as SchemaForm } from './components/SchemaForm';
 


### PR DESCRIPTION
### About

This PR adds SearchField component.

### Usage example

### Simple use

```
     <SearchField
          defaultValue={defaultValue}
          onDebouncedSearchChange={search =>
            makeRequestToApi(search)
          }
     />
```

### Search icon placement

```
     <SearchField
          onDebouncedSearchChange={search =>
            makeRequestToApi(search)
          }
          searchIconPlacement="start" // by default it is set to "end"
     />
```

### Accepts every prop TextField from MUI accepts

```
     <SearchField
          size="small"
          placeholder="Search by anything you want"
          onDebouncedSearchChange={search =>
            makeRequestToApi(search)
          }
     />
```