### PR TITLE
Fix lines that cause warning on other projects

### DIFF
--- a/packages/react-material-ui/src/components/Drawer/Styles.tsx
+++ b/packages/react-material-ui/src/components/Drawer/Styles.tsx
@@ -12,7 +12,12 @@ export type StyledDrawerProps = {
   expandedWidth?: string | number;
 };
 
-export const StyledDrawer = styled(MuiDrawer)<StyledDrawerProps>(
+export const StyledDrawer = styled(MuiDrawer, {
+  shouldForwardProp: (prop) =>
+    !['backgroundColor', 'collapsedWidth', 'expandedWidth'].some(
+      (propName) => propName === prop,
+    ),
+})<StyledDrawerProps>(
   ({
     theme,
     open,
@@ -59,7 +64,12 @@ export type DrawerButtonProps = {
   activeIconColor?: string;
 };
 
-export const DrawerButton = styled(MuiButton)<DrawerButtonProps>(
+export const DrawerButton = styled(MuiButton, {
+  shouldForwardProp: (prop) =>
+    !['active', 'collapsed', 'iconColor', 'activeIconColor'].some(
+      (propName) => propName === prop,
+    ),
+})<DrawerButtonProps>(
   ({
     theme,
     active,

--- a/packages/react-material-ui/src/components/Table/TableBody/TableBodyRows.tsx
+++ b/packages/react-material-ui/src/components/Table/TableBody/TableBodyRows.tsx
@@ -36,7 +36,7 @@ export const getPaginatedRows = (
  * @returns A React JSX element representing the default row.
  */
 const renderDefaultRow = (row: RowProps) => (
-  <TableBodyRow row={row}>
+  <TableBodyRow key={row.id} row={row}>
     <TableBodyCells row={row} />
   </TableBodyRow>
 );

--- a/packages/react-material-ui/src/components/Table/TableHeader/TableHeaderCells.tsx
+++ b/packages/react-material-ui/src/components/Table/TableHeader/TableHeaderCells.tsx
@@ -19,10 +19,12 @@ export const TableHeaderCells = ({ renderCell }: TableHeaderCellsProps) => {
   const { headers } = useTableRoot();
 
   if (!renderCell) {
-    return headers.map((header) => <TableHeaderCell cell={header} />);
+    return headers.map((header) => (
+      <TableHeaderCell key={header.id} cell={header} />
+    ));
   }
 
   return headers.map((header) => {
-    return renderCell(header);
+    return renderCell({ ...header, key: header.id });
   });
 };

--- a/packages/react-material-ui/src/components/Table/types.ts
+++ b/packages/react-material-ui/src/components/Table/types.ts
@@ -14,6 +14,7 @@ export type HeaderProps = {
   numeric?: boolean;
   textAlign?: 'left' | 'center' | 'right';
   sortable?: boolean;
+  key?: number | string;
 };
 
 export type CustomTableCell = {


### PR DESCRIPTION
Refactor lines that cause warning on projects that import specific components. Some of those warnings were caused by custom props bring forwarded to DOM elements, which led to the DOM not recognizing them as valid properties.

Further reference: [Mui Custom Components](https://mui.com/system/styled/#custom-components)