### PR TITLE
fix: add refresh token response to local storage

### DIFF
--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -44,6 +44,11 @@ const useDataProvider = () => {
           },
         });
 
+        if (response?.accessToken && response?.refreshToken) {
+          localStorage.setItem('accessToken', response.accessToken);
+          localStorage.setItem('refreshToken', response.refreshToken);
+        }
+
         return Promise.resolve(response);
       } catch (error) {
         localStorage.removeItem('accessToken');


### PR DESCRIPTION
This PR fixes the refresh token response not being exposed in the local storage.