### PR TITLE
Feature/data provider typing

### DIFF
--- a/packages/react-auth-provider/src/index.tsx
+++ b/packages/react-auth-provider/src/index.tsx
@@ -12,6 +12,7 @@ import {
   LoginParams,
   AuthProviderProps,
   AuthProviderTypes,
+  AuthReponse,
 } from './interfaces';
 
 const AuthContext = createContext<AuthProviderTypes | null>(null);
@@ -43,7 +44,7 @@ const AuthProvider = ({
       },
     });
 
-  const { execute, isPending } = useQuery(authLogin, false, {
+  const { execute, isPending } = useQuery<AuthReponse>(authLogin, false, {
     onSuccess: (data) => {
       if (data) {
         setAccessToken(data.accessToken);

--- a/packages/react-auth-provider/src/interfaces/index.ts
+++ b/packages/react-auth-provider/src/interfaces/index.ts
@@ -18,3 +18,8 @@ export type AuthProviderTypes = {
   accessToken: string;
   refreshToken: string;
 };
+
+export interface AuthReponse {
+  accessToken: string;
+  refreshToken: string;
+}

--- a/packages/react-data-provider/src/index.tsx
+++ b/packages/react-data-provider/src/index.tsx
@@ -9,15 +9,15 @@ import {
   AsyncStatus,
 } from './interfaces';
 
-const useQuery = <T extends AsyncFunction>(
-  asyncFn: T,
+const useQuery = <TQueryFn extends AsyncFunction, TError = unknown>(
+  asyncFn: TQueryFn,
   immediate = false,
-  options?: DataProviderRequestOptions,
+  options?: DataProviderRequestOptions<AsyncReturnType<TQueryFn>, TError>,
   arg?: unknown,
 ) => {
   const [status, setStatus] = useState(AsyncStatus.idle);
-  const [data, setData] = useState<AsyncReturnType<T>>();
-  const [error, setError] = useState<unknown>();
+  const [data, setData] = useState<AsyncReturnType<TQueryFn>>();
+  const [error, setError] = useState<TError>();
   const [isPending, setIsPending] = useState(false);
 
   const { onError, onSuccess, onFinish, formatData } = options || {};

--- a/packages/react-data-provider/src/index.tsx
+++ b/packages/react-data-provider/src/index.tsx
@@ -5,18 +5,17 @@ import ClientProvider from './ClientProvider';
 import {
   AsyncFunction,
   DataProviderRequestOptions,
-  AsyncReturnType,
   AsyncStatus,
 } from './interfaces';
 
-const useQuery = <TQueryFn extends AsyncFunction, TError = unknown>(
-  asyncFn: TQueryFn,
+const useQuery = <TQueryData, TError = unknown>(
+  asyncFn: AsyncFunction,
   immediate = false,
-  options?: DataProviderRequestOptions<AsyncReturnType<TQueryFn>, TError>,
+  options?: DataProviderRequestOptions<TQueryData, TError>,
   arg?: unknown,
 ) => {
   const [status, setStatus] = useState(AsyncStatus.idle);
-  const [data, setData] = useState<AsyncReturnType<TQueryFn>>();
+  const [data, setData] = useState<TQueryData>();
   const [error, setError] = useState<TError>();
   const [isPending, setIsPending] = useState(false);
 

--- a/packages/react-data-provider/src/interfaces/index.ts
+++ b/packages/react-data-provider/src/interfaces/index.ts
@@ -6,20 +6,20 @@ export interface RequestParams {
   signal?: AbortSignal;
 }
 
-export type PostRequestOptions<TRequestBody = any> = Omit<
+export type PostRequestOptions<TRequestBody = unknown> = Omit<
   RequestParams,
   'method'
 > & {
   body?: TRequestBody;
 };
 export type GetRequestOptions = Omit<RequestParams, 'method'>;
-export type PutRequestOptions<TRequestBody = any> = Omit<
+export type PutRequestOptions<TRequestBody = unknown> = Omit<
   RequestParams,
   'method'
 > & {
   body?: TRequestBody;
 };
-export type PatchRequestOptions<TRequestBody = any> = Omit<
+export type PatchRequestOptions<TRequestBody = unknown> = Omit<
   RequestParams,
   'method'
 > & {

--- a/packages/react-data-provider/src/interfaces/index.ts
+++ b/packages/react-data-provider/src/interfaces/index.ts
@@ -6,11 +6,24 @@ export interface RequestParams {
   signal?: AbortSignal;
 }
 
-export type PostRequestOptions = Omit<RequestParams, 'method'> & { body?: any };
+export type PostRequestOptions<TRequestBody = any> = Omit<
+  RequestParams,
+  'method'
+> & {
+  body?: TRequestBody;
+};
 export type GetRequestOptions = Omit<RequestParams, 'method'>;
-export type PutRequestOptions = Omit<RequestParams, 'method'> & { body?: any };
-export type PatchRequestOptions = Omit<RequestParams, 'method'> & {
-  body?: any;
+export type PutRequestOptions<TRequestBody = any> = Omit<
+  RequestParams,
+  'method'
+> & {
+  body?: TRequestBody;
+};
+export type PatchRequestOptions<TRequestBody = any> = Omit<
+  RequestParams,
+  'method'
+> & {
+  body?: TRequestBody;
 };
 export type DeleteRequestOptions = Omit<RequestParams, 'method'>;
 
@@ -63,9 +76,16 @@ export interface AsyncFunction {
 export type AsyncReturnType<T extends (...args: any) => Promise<any>> =
   T extends (...args: any) => Promise<infer R> ? R : any;
 
-export interface DataProviderRequestOptions {
-  onError?: (error: unknown) => void;
-  onSuccess?: (data: AsyncReturnType<any>) => void;
+type ErrorFn<TError = unknown> = (error: TError) => void;
+type SuccessFn<TData = AsyncReturnType<any>> = (data: TData) => void;
+type FormatFn<TData = AsyncReturnType<any>> = (data: TData) => any;
+
+export interface DataProviderRequestOptions<
+  TQueryFnData = any,
+  TError = unknown,
+> {
+  onError?: ErrorFn<TError>;
+  onSuccess?: SuccessFn<TQueryFnData>;
   onFinish?: (status: AsyncStatus) => void;
-  formatData?: (data: AsyncReturnType<any>) => any;
+  formatData?: FormatFn<TQueryFnData>;
 }

--- a/packages/react-data-provider/src/interfaces/index.ts
+++ b/packages/react-data-provider/src/interfaces/index.ts
@@ -73,19 +73,28 @@ export interface AsyncFunction {
   (params?: any): Promise<any>;
 }
 
-export type AsyncReturnType<T extends (...args: any) => Promise<any>> =
-  T extends (...args: any) => Promise<infer R> ? R : any;
+export type AsyncReturnType<T extends (...args: any) => Promise<unknown>> =
+  T extends (...args: any) => Promise<infer R> ? R : unknown;
 
 type ErrorFn<TError = unknown> = (error: TError) => void;
 type SuccessFn<TData = AsyncReturnType<any>> = (data: TData) => void;
-type FormatFn<TData = AsyncReturnType<any>> = (data: TData) => any;
+type FormatFn<TData = AsyncReturnType<any>> = (data: TData) => unknown;
 
 export interface DataProviderRequestOptions<
-  TQueryFnData = any,
+  TQueryFnData = unknown,
   TError = unknown,
 > {
   onError?: ErrorFn<TError>;
   onSuccess?: SuccessFn<TQueryFnData>;
   onFinish?: (status: AsyncStatus) => void;
   formatData?: FormatFn<TQueryFnData>;
+}
+
+export interface RefreshTokenBody {
+  refreshToken: string;
+}
+
+export interface RefreshTokenRes {
+  accessToken: string;
+  refreshToken: string;
 }

--- a/packages/react-data-provider/src/interfaces/index.ts
+++ b/packages/react-data-provider/src/interfaces/index.ts
@@ -1,8 +1,10 @@
+import { AxiosRequestConfig } from 'axios';
+
 export interface RequestParams {
   uri: string;
   method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'PATCH';
-  headers?: any;
-  queryParams?: any;
+  headers?: Record<string, string>;
+  queryParams?: Record<string, string | number>;
   signal?: AbortSignal;
 }
 
@@ -29,20 +31,20 @@ export type DeleteRequestOptions = Omit<RequestParams, 'method'>;
 
 export interface HttpBaseConfigs {
   skipAuthUris: string[];
-  headers: any;
+  headers: Record<string, string>;
   baseURL: string;
 }
 
 export interface HttpResponse {
-  config: any;
+  config: AxiosRequestConfig;
   data: any;
-  headers: any;
-  status: any;
+  headers: Record<string, string>;
+  status: number;
 }
 
 export interface HttpError {
   response: HttpResponse;
-  code: any;
+  code: number;
   message: string;
 }
 

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -83,20 +83,20 @@ const useDataProvider = () => {
     },
   });
 
-  const makeRequest = (requestParams: RequestParams) => {
+  const makeRequest = <TResponse>(requestParams: RequestParams) => {
     return client
       .executeRequest(requestParams)
-      .then((res) => handleServerResponse(res))
+      .then((res) => handleServerResponse<TResponse>(res))
       .catch((err) => handleServerError(err));
   };
 
   //TODO
   //if we need to normalize response no matter what client we are using or use a custom response
   //that will be more user friendly
-  const handleServerResponse = (response: HttpResponse) => {
+  const handleServerResponse = <TResponse = any>(response: HttpResponse) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { config, data, headers, status } = response;
-    return data;
+    return data as TResponse;
   };
 
   //TODO
@@ -108,39 +108,39 @@ const useDataProvider = () => {
     throw err;
   };
 
-  const post = async <TRequestBody>(
+  const post = async <TRequestBody, TResponse = any>(
     requestParams: PostRequestOptions<TRequestBody>,
   ) => {
-    return makeRequest({
+    return makeRequest<TResponse>({
       ...requestParams,
       method: 'POST',
     });
   };
 
-  const get = async (requestParams: GetRequestOptions) => {
-    return makeRequest({
+  const get = async <TResponse = any>(requestParams: GetRequestOptions) => {
+    return makeRequest<TResponse>({
       ...requestParams,
       method: 'GET',
     });
   };
-  const put = async <TRequestBody>(
+  const put = async <TRequestBody, TResponse = any>(
     requestParams: PutRequestOptions<TRequestBody>,
   ) => {
-    return makeRequest({
+    return makeRequest<TResponse>({
       ...requestParams,
       method: 'PUT',
     });
   };
-  const patch = async <TRequestBody>(
+  const patch = async <TRequestBody, TResponse = any>(
     requestParams: PatchRequestOptions<TRequestBody>,
   ) => {
-    return makeRequest({
+    return makeRequest<TResponse>({
       ...requestParams,
       method: 'PATCH',
     });
   };
-  const del = async (requestParams: DeleteRequestOptions) => {
-    return makeRequest({
+  const del = async <TResponse = any>(requestParams: DeleteRequestOptions) => {
+    return makeRequest<TResponse>({
       ...requestParams,
       method: 'DELETE',
     });

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -108,7 +108,9 @@ const useDataProvider = () => {
     throw err;
   };
 
-  const post = async (requestParams: PostRequestOptions) => {
+  const post = async <TRequestBody>(
+    requestParams: PostRequestOptions<TRequestBody>,
+  ) => {
     return makeRequest({
       ...requestParams,
       method: 'POST',
@@ -121,13 +123,17 @@ const useDataProvider = () => {
       method: 'GET',
     });
   };
-  const put = async (requestParams: PutRequestOptions) => {
+  const put = async <TRequestBody>(
+    requestParams: PutRequestOptions<TRequestBody>,
+  ) => {
     return makeRequest({
       ...requestParams,
       method: 'PUT',
     });
   };
-  const patch = async (requestParams: PatchRequestOptions) => {
+  const patch = async <TRequestBody>(
+    requestParams: PatchRequestOptions<TRequestBody>,
+  ) => {
     return makeRequest({
       ...requestParams,
       method: 'PATCH',

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -12,6 +12,8 @@ import {
   PatchRequestOptions,
   DeleteRequestOptions,
   Token,
+  RefreshTokenBody,
+  RefreshTokenRes,
 } from './interfaces';
 import { useClient } from './ClientProvider';
 
@@ -37,7 +39,7 @@ const useDataProvider = () => {
       try {
         const refreshToken = localStorage.getItem('refreshToken');
 
-        const response = await post({
+        const response = await post<RefreshTokenBody, RefreshTokenRes>({
           uri: '/token/refresh',
           body: {
             refreshToken,
@@ -93,7 +95,9 @@ const useDataProvider = () => {
   //TODO
   //if we need to normalize response no matter what client we are using or use a custom response
   //that will be more user friendly
-  const handleServerResponse = <TQueryData = any>(response: HttpResponse) => {
+  const handleServerResponse = <TQueryData = unknown>(
+    response: HttpResponse,
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { config, data, headers, status } = response;
     return data as TQueryData;
@@ -108,7 +112,7 @@ const useDataProvider = () => {
     throw err;
   };
 
-  const post = async <TRequestBody, TQueryData = any>(
+  const post = async <TRequestBody = unknown, TQueryData = unknown>(
     requestParams: PostRequestOptions<TRequestBody>,
   ) => {
     return makeRequest<TQueryData>({
@@ -117,13 +121,15 @@ const useDataProvider = () => {
     });
   };
 
-  const get = async <TQueryData = any>(requestParams: GetRequestOptions) => {
+  const get = async <TQueryData = unknown>(
+    requestParams: GetRequestOptions,
+  ) => {
     return makeRequest<TQueryData>({
       ...requestParams,
       method: 'GET',
     });
   };
-  const put = async <TRequestBody, TQueryData = any>(
+  const put = async <TRequestBody = unknown, TQueryData = unknown>(
     requestParams: PutRequestOptions<TRequestBody>,
   ) => {
     return makeRequest<TQueryData>({
@@ -131,7 +137,7 @@ const useDataProvider = () => {
       method: 'PUT',
     });
   };
-  const patch = async <TRequestBody, TQueryData = any>(
+  const patch = async <TRequestBody = unknown, TQueryData = unknown>(
     requestParams: PatchRequestOptions<TRequestBody>,
   ) => {
     return makeRequest<TQueryData>({
@@ -139,7 +145,9 @@ const useDataProvider = () => {
       method: 'PATCH',
     });
   };
-  const del = async <TQueryData = any>(requestParams: DeleteRequestOptions) => {
+  const del = async <TQueryData = unknown>(
+    requestParams: DeleteRequestOptions,
+  ) => {
     return makeRequest<TQueryData>({
       ...requestParams,
       method: 'DELETE',

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -83,20 +83,20 @@ const useDataProvider = () => {
     },
   });
 
-  const makeRequest = <TResponse>(requestParams: RequestParams) => {
+  const makeRequest = <TQueryData>(requestParams: RequestParams) => {
     return client
       .executeRequest(requestParams)
-      .then((res) => handleServerResponse<TResponse>(res))
+      .then((res) => handleServerResponse<TQueryData>(res))
       .catch((err) => handleServerError(err));
   };
 
   //TODO
   //if we need to normalize response no matter what client we are using or use a custom response
   //that will be more user friendly
-  const handleServerResponse = <TResponse = any>(response: HttpResponse) => {
+  const handleServerResponse = <TQueryData = any>(response: HttpResponse) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { config, data, headers, status } = response;
-    return data as TResponse;
+    return data as TQueryData;
   };
 
   //TODO
@@ -108,39 +108,39 @@ const useDataProvider = () => {
     throw err;
   };
 
-  const post = async <TRequestBody, TResponse = any>(
+  const post = async <TRequestBody, TQueryData = any>(
     requestParams: PostRequestOptions<TRequestBody>,
   ) => {
-    return makeRequest<TResponse>({
+    return makeRequest<TQueryData>({
       ...requestParams,
       method: 'POST',
     });
   };
 
-  const get = async <TResponse = any>(requestParams: GetRequestOptions) => {
-    return makeRequest<TResponse>({
+  const get = async <TQueryData = any>(requestParams: GetRequestOptions) => {
+    return makeRequest<TQueryData>({
       ...requestParams,
       method: 'GET',
     });
   };
-  const put = async <TRequestBody, TResponse = any>(
+  const put = async <TRequestBody, TQueryData = any>(
     requestParams: PutRequestOptions<TRequestBody>,
   ) => {
-    return makeRequest<TResponse>({
+    return makeRequest<TQueryData>({
       ...requestParams,
       method: 'PUT',
     });
   };
-  const patch = async <TRequestBody, TResponse = any>(
+  const patch = async <TRequestBody, TQueryData = any>(
     requestParams: PatchRequestOptions<TRequestBody>,
   ) => {
-    return makeRequest<TResponse>({
+    return makeRequest<TQueryData>({
       ...requestParams,
       method: 'PATCH',
     });
   };
-  const del = async <TResponse = any>(requestParams: DeleteRequestOptions) => {
-    return makeRequest<TResponse>({
+  const del = async <TQueryData = any>(requestParams: DeleteRequestOptions) => {
+    return makeRequest<TQueryData>({
       ...requestParams,
       method: 'DELETE',
     });

--- a/packages/react-material-ui/src/components/Table/types.ts
+++ b/packages/react-material-ui/src/components/Table/types.ts
@@ -15,6 +15,7 @@ export type HeaderProps = {
   textAlign?: 'left' | 'center' | 'right';
   sortable?: boolean;
   key?: number | string;
+  source?: string;
 };
 
 export type CustomTableCell = {
@@ -66,3 +67,11 @@ export type TableQueryStateProps = {
 };
 
 export type RenderRowFunction = (row: RowProps, labelId: string) => ReactNode;
+
+export type TableResponseData = {
+  data: unknown[];
+  count: number;
+  total: number;
+  page: number;
+  pageCount: number;
+};

--- a/packages/react-material-ui/src/components/Table/types.ts
+++ b/packages/react-material-ui/src/components/Table/types.ts
@@ -15,7 +15,6 @@ export type HeaderProps = {
   textAlign?: 'left' | 'center' | 'right';
   sortable?: boolean;
   key?: number | string;
-  source?: string;
 };
 
 export type CustomTableCell = {

--- a/packages/react-material-ui/src/components/Table/useTable.ts
+++ b/packages/react-material-ui/src/components/Table/useTable.ts
@@ -3,7 +3,13 @@
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
-import { Order, Search, SimpleFilter, TableQueryStateProps } from './types';
+import {
+  Order,
+  Search,
+  SimpleFilter,
+  TableQueryStateProps,
+  TableResponseData,
+} from './types';
 import {
   TABLE_QUERY_STATE_DEFAULT_VALUE,
   useTableQueryState,
@@ -113,11 +119,8 @@ const useTable: UseTableProps = (resource, options) => {
     });
   };
 
-  const { data, execute, refresh, isPending, error } = useQuery(
-    getResource,
-    false,
-    options?.callbacks,
-  );
+  const { data, execute, refresh, isPending, error } =
+    useQuery<TableResponseData>(getResource, false, options?.callbacks);
 
   // TODO: This will be refactored with Query Builder
   // For now it works even though not optmized

--- a/packages/react-material-ui/src/styles/CustomWidgets/CustomAutocompleteWidget.tsx
+++ b/packages/react-material-ui/src/styles/CustomWidgets/CustomAutocompleteWidget.tsx
@@ -102,7 +102,7 @@ export default function CustomAutocompleteWidget<
       queryParams,
     });
   };
-  const { execute, data, isPending } = useQuery(getResource, false);
+  const { execute, data, isPending } = useQuery<unknown[]>(getResource, false);
 
   const resourceOptions = [
     ...(Array.isArray(additionalOptions) ? additionalOptions : []),


### PR DESCRIPTION
### Solves

Tickets: [Data Provider](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1252), [Remove ANYs](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1256)

Improves Data Provider types.


### How to use
When using the requests together with `useQuery`, you can pass two generics `<TQueryData, TError = unknown>`. The first one is forwarded to the response in the `onSuccess` function. The second one is forwarded to the `onError` function.


``` typescript
const postNewUser = () =>
  post<UserCreate>({
    uri: "/user",
    body: {
      // UserCreate type is passed automatically to the body
      email: "",
      fullName: "",
      password: "",
    },
  })

const { data, execute, isPending, error } = useQuery<User[], ErrorType>(postNewUser, false, {
  onSuccess: (res) => {
    // User[] is passed automatically to the response
    console.log("res", res);
  },
  onError: (err) => {
    // ErrorType is passed automatically to the error reponse
    console.log("Failed to load user details");
  }
});
```


You can also use the requests individually, without `useQuery`. Get and delete requests uses one generic type that is forwarded to it's response

``` typescript
get<User[]>({
  uri: "/user",
}).then((res) => {
  // User[] type is passed automatically to the response
});

del<DelRes>({
  uri: "/user",
}).then((res) => {
  // DelRes type is passed automatically to the response
})
```

Post, put and patch requests uses two generic types. The first one is forwarded to the body and the second one is forwarded to the response.

``` typescript
post<UserCreate, PostRes>({
  uri: "/user",
  body: {
    // UserCreate type is passed automatically to the body
    email: "",
    fullName: "",
    password: "",
  },
}).then((res) => {
  // PostRes type is passed automatically to the response
});


put<UserCreate, PostRes>({
  uri: "/user",
  body: {
    // UserCreate type is passed automatically to the body
    email: "",
    fullName: "",
    password: "",
  },
}).then((res) => {
  // PostRes type is passed automatically to the response
});

patch<UserCreate, PostRes>({
  uri: "/user",
  body: {
    // UserCreate type is passed automatically to the body
    email: "",
    fullName: "",
    password: "",
  },
}).then((res) => {
  // PostRes type is passed automatically to the response
});
```

### Preview
![Screenshot 2024-01-30 111034](https://github.com/conceptadev/rockets-react/assets/32578927/3bb3f59a-32e2-4a5c-bb3a-db0a3e89aae8)
![Screenshot 2024-01-30 111048](https://github.com/conceptadev/rockets-react/assets/32578927/94d76aaa-f553-43ba-bbef-b5050c128bdd)
![Screenshot 2024-01-30 111059](https://github.com/conceptadev/rockets-react/assets/32578927/2e2c1f4a-d74f-4512-a51d-d4b9da9265e4)
![Screenshot 2024-01-30 111106](https://github.com/conceptadev/rockets-react/assets/32578927/637f4583-e3c3-4f17-95e3-b7e64732ff39)
