### PR TITLE
Implement feedback handlers as module props

### DIFF
--- a/packages/react-material-ui/package.json
+++ b/packages/react-material-ui/package.json
@@ -36,8 +36,7 @@
     "lodash": "^4.17.21",
     "next": "^13.4.19",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-toastify": "^10.0.4"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.198",

--- a/packages/react-material-ui/src/components/submodules/AuthForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/AuthForm/index.tsx
@@ -9,9 +9,8 @@ import type { ValidationRule } from '../../../utils/form/validation';
 import { useState } from 'react';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import { useAuth } from '@concepta/react-auth-provider';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import validator from '@rjsf/validator-ajv6';
-import { toast } from 'react-toastify';
 import { Box, Button, Container, Card, CircularProgress } from '@mui/material';
 
 import Text from '../../../components/Text';
@@ -51,15 +50,14 @@ interface AuthFormSubmoduleProps {
   customValidation?: ValidationRule<Record<string, string>>[];
   submitButtonTitle?: string;
   logoSrc?: string;
-  successFeedbackMessage?: string;
-  errorFeedbackMessage?: string;
+  onSuccess?: (data: unknown) => void;
+  onError?: (error: unknown) => void;
   overrideDefaults?: boolean;
 }
 
 const AuthFormSubmodule = (props: AuthFormSubmoduleProps) => {
   const [formData, setFormData] = useState<Record<string, unknown>>({});
 
-  const router = useRouter();
   const searchParams = useSearchParams();
   const passcode = searchParams.get('token');
 
@@ -81,21 +79,8 @@ const AuthFormSubmodule = (props: AuthFormSubmoduleProps) => {
       }),
     false,
     {
-      onSuccess() {
-        toast.success(props.successFeedbackMessage || 'Success!');
-
-        if (props.signInPath) {
-          router.push(props.signInPath);
-        }
-      },
-      onError: (error) => {
-        toast.error(
-          props.errorFeedbackMessage ||
-            // @ts-expect-error TODO: fix types in rockets-react
-            error?.response?.data?.message ||
-            'An error has occurred. Please try again later or contact support for assistance.',
-        );
-      },
+      onSuccess: props.onSuccess,
+      onError: props.onError,
     },
   );
 

--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -6,7 +6,6 @@ import type { IChangeEvent, FormProps } from '@rjsf/core';
 import { Box, Drawer, Button, CircularProgress } from '@mui/material';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import validator from '@rjsf/validator-ajv6';
-import { toast } from 'react-toastify';
 
 import SchemaForm, { SchemaFormProps } from '../../../components/SchemaForm';
 
@@ -37,15 +36,15 @@ type DrawerFormSubmoduleProps = PropsWithChildren<
   submitButtonTitle?: string;
   cancelButtonTitle?: string;
   onClose?: () => void;
-  onSubmitSuccess?: () => void;
   customValidate?: CustomValidator;
   widgets?: FormProps['widgets'];
+  onSuccess?: (data: unknown) => void;
+  onError?: (error: unknown) => void;
 };
 
 const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
   const {
     queryResource,
-    onSubmitSuccess,
     viewMode,
     widgets,
     formSchema,
@@ -56,6 +55,8 @@ const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
     onClose,
     cancelButtonTitle,
     children,
+    onSuccess,
+    onError,
     ...otherProps
   } = props;
   const { post, patch } = useDataProvider();
@@ -68,14 +69,8 @@ const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
       }),
     false,
     {
-      onSuccess: () => {
-        toast.success('Data successfully created.');
-
-        if (onSubmitSuccess) {
-          onSubmitSuccess();
-        }
-      },
-      onError: () => toast.error('Failed to create data.'),
+      onSuccess: onSuccess,
+      onError: onError,
     },
   );
 
@@ -87,14 +82,8 @@ const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
       }),
     false,
     {
-      onSuccess: () => {
-        toast.success('Data successfully updated.');
-
-        if (onSubmitSuccess) {
-          onSubmitSuccess();
-        }
-      },
-      onError: () => toast.error('Failed to edit data.'),
+      onSuccess: onSuccess,
+      onError: onError,
     },
   );
 

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -14,7 +14,6 @@ import {
 import { Close as CloseIcon } from '@mui/icons-material';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import validator from '@rjsf/validator-ajv6';
-import { toast } from 'react-toastify';
 
 import SchemaForm, { SchemaFormProps } from '../../../components/SchemaForm';
 import { CustomTextFieldWidget } from '../../../styles/CustomWidgets';
@@ -44,16 +43,15 @@ type ModalFormSubmoduleProps = PropsWithChildren<
   submitButtonTitle?: string;
   cancelButtonTitle?: string;
   onClose?: () => void;
-  onSubmitSuccess?: () => void;
-  overrideDefaults?: boolean;
   customValidate?: CustomValidator;
   widgets?: FormProps['widgets'];
+  onSuccess?: (data: unknown) => void;
+  onError?: (error: unknown) => void;
 };
 
 const ModalFormSubmodule = (props: ModalFormSubmoduleProps) => {
   const {
     queryResource,
-    onSubmitSuccess,
     viewMode,
     widgets,
     onClose,
@@ -65,6 +63,8 @@ const ModalFormSubmodule = (props: ModalFormSubmoduleProps) => {
     submitButtonTitle,
     cancelButtonTitle,
     children,
+    onSuccess,
+    onError,
     ...otherProps
   } = props;
 
@@ -78,14 +78,8 @@ const ModalFormSubmodule = (props: ModalFormSubmoduleProps) => {
       }),
     false,
     {
-      onSuccess: () => {
-        toast.success('Data successfully created.');
-
-        if (onSubmitSuccess) {
-          onSubmitSuccess();
-        }
-      },
-      onError: () => toast.error('Failed to create data.'),
+      onSuccess: onSuccess,
+      onError: onError,
     },
   );
 
@@ -97,14 +91,8 @@ const ModalFormSubmodule = (props: ModalFormSubmoduleProps) => {
       }),
     false,
     {
-      onSuccess: () => {
-        toast.success('Data successfully updated.');
-
-        if (onSubmitSuccess) {
-          onSubmitSuccess();
-        }
-      },
-      onError: () => toast.error('Failed to edit data.'),
+      onSuccess: onSuccess,
+      onError: onError,
     },
   );
 

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -26,7 +26,6 @@ import {
   ChevronRight as ChevronRightIcon,
 } from '@mui/icons-material';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
-import { toast } from 'react-toastify';
 
 import Filter from '../../../components/Filter';
 import { FilterType } from '../../../components/Filter/Filter';
@@ -90,6 +89,8 @@ interface TableSubmoduleProps {
   hideDeleteButton?: boolean;
   hideDetailsButton?: boolean;
   hideAddButton?: boolean;
+  onDeleteSuccess?: (data: unknown) => void;
+  onDeleteError?: (error: unknown) => void;
 }
 
 const TableSubmodule = (props: TableSubmoduleProps) => {
@@ -106,14 +107,16 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
       }),
     false,
     {
-      onSuccess: () => {
-        toast.success('Data successfully deleted.');
-
+      onSuccess: (data: unknown) => {
         if (props.refresh) {
           props.refresh();
         }
+
+        if (props.onDeleteSuccess) {
+          props.onDeleteSuccess(data);
+        }
       },
-      onError: () => toast.error('Failed to delete data.'),
+      onError: props.onDeleteError,
     },
   );
 

--- a/packages/react-material-ui/src/modules/auth/README.md
+++ b/packages/react-material-ui/src/modules/auth/README.md
@@ -25,7 +25,7 @@ Array of rules to validate one or more fields in a more specific logic. Each arr
 ```js
 [
   {
-    field: "passwordConfirmation",
+    field: 'passwordConfirmation',
     test: (value, formData) => value !== formData.password,
     message: "Passwords don't match!",
   },
@@ -133,6 +133,20 @@ Source of the logo image displayed above the form card.
 
 **type**: `string`\
 **default**: `/logo.svg`\
+**required**: `false`
+
+### **onSuccess**
+
+Callback called when the form's submit method returns successfully.
+
+**type**: `function`\
+**required**: `false`
+
+### **onError**
+
+Callback called when the form's submit method returns an error.
+
+**type**: `function`\
 **required**: `false`
 
 ## Props

--- a/packages/react-material-ui/src/modules/auth/index.tsx
+++ b/packages/react-material-ui/src/modules/auth/index.tsx
@@ -32,8 +32,8 @@ interface ModuleProps {
   queryMethod?: string;
   submitButtonTitle?: string;
   logoSrc?: string;
-  successFeedbackMessage?: string;
-  errorFeedbackMessage?: string;
+  onSuccess?: (data: unknown) => void;
+  onError?: (error: unknown) => void;
 }
 
 interface AuthModuleProps {

--- a/packages/react-material-ui/src/modules/crud/README.md
+++ b/packages/react-material-ui/src/modules/crud/README.md
@@ -21,12 +21,12 @@ Important to mention that `format` represents a custom format for the column dat
 ```js
 [
   {
-    id: "fullName", // required
-    label: "Full Name", // required
+    id: 'fullName', // required
+    label: 'Full Name', // required
     disablePadding: false,
     width: 100,
     numeric: false,
-    textAlign: "left" | "center" | "right",
+    textAlign: 'left' | 'center' | 'right',
     sortable: true,
     format: (value: string | number) => new Date(value).toString(),
   },
@@ -61,7 +61,21 @@ Based on this prop, the table defaults can be overritten and only the values pas
 **default**: `false`\
 **required**: `false`
 
-## **DrawerFormProps**
+### **onDeleteSuccess**
+
+Callback called when the an item of the table is deleted successfully.
+
+**type**: `function`\
+**required**: `false`
+
+### **onDeleteError**
+
+Callback called when the delete item request returns an error.
+
+**type**: `function`\
+**required**: `false`
+
+## **FormProps**
 
 Props passed to modify layout/functionality of the edit/create form, displayed on a drawer by default.
 
@@ -103,6 +117,20 @@ Based on this prop, the edit/create form defaults can be overritten and only the
 **default**: `false`\
 **required**: `false`
 
+### **onSuccess**
+
+Callback called when the form's submit method returns successfully.
+
+**type**: `function`\
+**required**: `false`
+
+### **onError**
+
+Callback called when the form's submit method returns an error.
+
+**type**: `function`\
+**required**: `false`
+
 ## Props
 
 Set of props passed to the `CrudModule` instance.
@@ -134,5 +162,12 @@ Name of the API resource accessed by the module workflows. Directly implies how 
 
 ### **formProps**
 
-**type**: `DrawerFormProps`\
+**type**: `FormProps`\
+**required**: `false`
+
+### **onFetchError**
+
+Callback called when the table data fetching returns an error.
+
+**type**: `function`\
 **required**: `false`

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -6,7 +6,6 @@ import type { HeaderProps } from '../../components/Table/types';
 
 import { useMemo, useState } from 'react';
 import { Box } from '@mui/material';
-import { toast } from 'react-toastify';
 
 import useTable from '../../components/Table/useTable';
 import { TableProps as InnerTableProps } from '../../components/Table/Table';
@@ -31,6 +30,8 @@ interface TableProps {
   tableTheme?: StyleDefinition;
   searchParam?: string;
   hideActionsColumn?: boolean;
+  onDeleteSuccess?: (data: unknown) => void;
+  onDeleteError?: (error: unknown) => void;
 }
 
 interface FormProps {
@@ -39,6 +40,8 @@ interface FormProps {
   submitButtonTitle?: string;
   cancelButtonTitle?: string;
   customValidate?: CustomValidator;
+  onSuccess?: (data: unknown) => void;
+  onError?: (error: unknown) => void;
 }
 
 interface ModuleProps {
@@ -50,6 +53,7 @@ interface ModuleProps {
   createFormProps?: PropsWithChildren<FormProps>;
   editFormProps?: PropsWithChildren<FormProps>;
   hideDeleteButton?: boolean;
+  onFetchError?: (error: unknown) => void;
 }
 
 const CrudModule = (props: ModuleProps) => {
@@ -58,7 +62,7 @@ const CrudModule = (props: ModuleProps) => {
 
   const tableProps = useTable(props.resource, {
     callbacks: {
-      onError: () => toast.error('Failed to fetch data.'),
+      onError: props.onFetchError,
     },
   });
 
@@ -123,10 +127,14 @@ const CrudModule = (props: ModuleProps) => {
           queryResource={props.resource}
           viewMode={drawerViewMode}
           formData={selectedRow}
-          onSubmitSuccess={() => {
+          onSuccess={(data) => {
             tableProps.refresh();
             setSelectedRow(null);
             setDrawerViewMode(null);
+
+            if (formProps.onSuccess) {
+              formProps.onSuccess(data);
+            }
           }}
           onClose={() => {
             setSelectedRow(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8148,13 +8148,6 @@ react-router@6.21.3:
   dependencies:
     "@remix-run/router" "1.14.2"
 
-react-toastify@^10.0.4:
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.4.tgz#6ecdbbf923a07fc45850e69b0566efc7bf733283"
-  integrity sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==
-  dependencies:
-    clsx "^2.1.0"
-
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
Implementaion of handler props for success/error on modules. The reason for that is beacuse having an opinionated `toast` implementation for those types of functions doesn't work on other projects.