### PR TITLE
Feature/crud module orderable filters

### DIFF
--- a/packages/react-material-ui/__tests__/Filter.spec.tsx
+++ b/packages/react-material-ui/__tests__/Filter.spec.tsx
@@ -5,7 +5,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import { render } from '@testing-library/react';
-import Filter, { FilterType } from '../src/components/Filter/Filter';
+import Filter from '../src/components/Filter/Filter';
 
 describe('Filter Component', () => {
   it('renders textfield component if type is "Text"', () => {
@@ -13,7 +13,9 @@ describe('Filter Component', () => {
       <Filter
         filters={[
           {
-            type: FilterType['Text'],
+            id: 'text',
+            label: 'Text',
+            type: 'text',
             placeholder: 'Test Placeholder',
             onChange: jest.fn(),
           },
@@ -30,7 +32,8 @@ describe('Filter Component', () => {
       <Filter
         filters={[
           {
-            type: FilterType['Autocomplete'],
+            id: 'autocomplete',
+            type: 'autocomplete',
             options: [
               {
                 label: 'Test',
@@ -54,7 +57,8 @@ describe('Filter Component', () => {
       <Filter
         filters={[
           {
-            type: FilterType['Select'],
+            id: 'select',
+            type: 'select',
             options: [
               {
                 label: 'Test',
@@ -77,12 +81,15 @@ describe('Filter Component', () => {
       <Filter
         filters={[
           {
-            type: FilterType['Text'],
+            id: 'text',
+            label: 'Text',
+            type: 'text',
             placeholder: 'Text Test Placeholder',
             onChange: jest.fn(),
           },
           {
-            type: FilterType['Autocomplete'],
+            id: 'autocomplete',
+            type: 'autocomplete',
             options: [
               {
                 label: 'Autocomplete Test',
@@ -94,7 +101,8 @@ describe('Filter Component', () => {
             isLoading: false,
           },
           {
-            type: FilterType['Select'],
+            id: 'select',
+            type: 'select',
             options: [
               {
                 label: 'Test',

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -14,13 +14,9 @@ import {
 import { SearchFieldProps } from '../../components/SearchField/SearchField';
 import OrderableDropDown, { ListItem } from '../OrderableDropDown';
 
-export enum FilterType {
-  Text = 'text',
-  Autocomplete = 'autocomplete',
-  Select = 'select',
-}
+export type FilterVariant = 'text' | 'autocomplete' | 'select';
 
-type FilterCommon = {
+export type FilterCommon = {
   id: string;
   label: string;
   isLoading?: boolean;
@@ -31,16 +27,16 @@ type FilterCommon = {
 };
 
 type TextFilter = {
-  type: FilterType.Text;
+  type: 'text';
   placeholder?: string;
   defaultValue?: string;
-  onChange: (value: string) => void;
+  onChange?: (value: string) => void;
   onDebouncedSearchChange?: (value: string) => void;
   value?: string;
 } & FilterCommon;
 
 type AutocompleteFilter = {
-  type: FilterType.Autocomplete;
+  type: 'autocomplete';
   options: SelectOption[];
   currentValue?: string;
   defaultValue?: SelectOption;
@@ -48,7 +44,7 @@ type AutocompleteFilter = {
 } & FilterCommon;
 
 type SelectFilter = {
-  type: FilterType.Select;
+  type: 'select';
   options: SelectOption[];
   defaultValue?: string;
   size?: SelectFieldProps['size'];
@@ -56,9 +52,9 @@ type SelectFilter = {
   value?: string | null;
 } & FilterCommon;
 
-export type Filter = TextFilter | AutocompleteFilter | SelectFilter;
+export type FilterType = TextFilter | AutocompleteFilter | SelectFilter;
 
-const renderComponent = (filter: Filter) => {
+const renderComponent = (filter: FilterType) => {
   switch (filter.type) {
     case 'autocomplete': {
       return (
@@ -114,7 +110,7 @@ const renderComponent = (filter: Filter) => {
 };
 
 export type FilterProps = {
-  filters: Filter[];
+  filters: FilterType[];
 } & GridProps;
 
 const Filter = (props: FilterProps) => {

--- a/packages/react-material-ui/src/components/Filter/index.ts
+++ b/packages/react-material-ui/src/components/Filter/index.ts
@@ -1,3 +1,4 @@
-import Filter from './Filter';
+import Filter, { FilterVariant, FilterCommon, FilterType } from './Filter';
 
+export { FilterVariant, FilterCommon, FilterType };
 export default Filter;

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -135,7 +135,7 @@ const OrderableDropDown: FC<Props> = ({ list, setList }) => {
   };
 
   return (
-    <Box display="flex" justifyContent="flex-end" mb={2}>
+    <Box>
       <IconButton
         onClick={(event: React.MouseEvent<HTMLElement>) => {
           setAnchorEl(event.currentTarget);

--- a/packages/react-material-ui/src/components/SearchField/SearchField.tsx
+++ b/packages/react-material-ui/src/components/SearchField/SearchField.tsx
@@ -48,10 +48,9 @@ const SearchField = ({
 
   const value = props.value ?? search;
 
-  const handleDebouncedSearch = useMemo(
-    () => debounce(onDebouncedSearchChange, wait),
-    [],
-  );
+  const handleDebouncedSearch =
+    onDebouncedSearchChange &&
+    useMemo(() => debounce(onDebouncedSearchChange, wait), []);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);

--- a/packages/react-material-ui/src/components/Table/types.ts
+++ b/packages/react-material-ui/src/components/Table/types.ts
@@ -4,6 +4,11 @@ export type BasicType = string | number | boolean;
 
 export type SimpleFilter = Record<string, BasicType | BasicType[] | null>;
 
+export type UpdateSimpleFilter = (
+  simpleFilter: SimpleFilter | null,
+  resetPage?: boolean,
+) => void;
+
 export type Search = Record<string, any>;
 
 export type HeaderProps = {

--- a/packages/react-material-ui/src/components/Table/useTable.ts
+++ b/packages/react-material-ui/src/components/Table/useTable.ts
@@ -7,6 +7,7 @@ import {
   Order,
   Search,
   SimpleFilter,
+  UpdateSimpleFilter,
   TableQueryStateProps,
   TableResponseData,
 } from './types';
@@ -39,10 +40,7 @@ export type UseTableProps = (
   pageCount: number;
   execute: () => void;
   refresh: () => void;
-  updateSimpleFilter: (
-    simpleFilter: SimpleFilter | null,
-    resetPage?: boolean,
-  ) => void;
+  updateSimpleFilter: UpdateSimpleFilter;
   updateSearch: (search: Search | null, resetPage?: boolean) => void;
   simpleFilter: SimpleFilter;
   search: Search;

--- a/packages/react-material-ui/src/components/submodules/Filter/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Filter/index.tsx
@@ -1,0 +1,104 @@
+import React, { FC, useState } from 'react';
+import Filter, {
+  FilterVariant,
+  FilterCommon,
+  FilterType,
+} from '../../../components/Filter';
+import { SelectOption } from '../../../components/SelectField/SelectField';
+import { UpdateSimpleFilter, SimpleFilter } from 'components/Table/types';
+
+type Operator =
+  | 'eq'
+  | 'ne'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'lte'
+  | 'starts'
+  | 'ends'
+  | 'cont'
+  | 'excl'
+  | 'eqL'
+  | 'neL'
+  | 'startsL'
+  | 'endsL'
+  | 'contL'
+  | 'exclL';
+
+export type FilterDetails = {
+  operator: Operator;
+  type: FilterVariant;
+  options?: SelectOption[];
+} & Omit<FilterCommon, 'showOnMount' | 'hide'>;
+
+interface Props {
+  filters: FilterDetails[];
+  updateSimpleFilter: UpdateSimpleFilter;
+  simpleFilter: SimpleFilter;
+}
+
+const FilterSubmodule: FC<Props> = ({
+  filters,
+  updateSimpleFilter,
+  simpleFilter,
+}) => {
+  const [filterValues, setFilterValues] = useState<
+    Record<string, string | null>
+  >({});
+
+  const onFilterChange = (
+    id: string,
+    value: string | null,
+    updateFilter?: boolean,
+  ) => {
+    const _filterValues = { ...filterValues, [id]: value };
+    setFilterValues(_filterValues);
+
+    if (updateFilter) {
+      const simpleFilter = filters.reduce((acc, filter) => {
+        const value = _filterValues[filter.id];
+
+        if (typeof value === 'undefined') return acc;
+
+        return {
+          ...acc,
+          [filter.id]:
+            value === null || value === 'all' || value === ''
+              ? null
+              : `||$${filter.operator}||${value}`,
+        };
+      }, {});
+
+      updateSimpleFilter(simpleFilter, true);
+    }
+  };
+
+  const filterObjs: FilterType[] = filters.map((filter) => {
+    const { id, label, columns, type, options, operator } = filter;
+
+    const initialValue = String(simpleFilter?.[id])?.split('||')[2];
+
+    const value = filterValues[id] ?? initialValue;
+
+    return {
+      id,
+      label,
+      columns,
+      type,
+      options,
+      operator,
+      value,
+      onChange: (val: string | null) => onFilterChange(id, val, true),
+      ...(type === 'text' && {
+        onChange: (val: string | null) => onFilterChange(id, val, false),
+        onDebouncedSearchChange: (val: string) => onFilterChange(id, val, true),
+      }),
+    };
+  });
+
+  if (filters.length === 0) return null;
+
+  return <Filter filters={filterObjs} />;
+};
+
+export default FilterSubmodule;

--- a/packages/react-material-ui/src/components/submodules/Filter/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Filter/index.tsx
@@ -74,7 +74,8 @@ const FilterSubmodule: FC<Props> = ({
   };
 
   const filterObjs: FilterType[] = filters.map((filter) => {
-    const { id, label, columns, type, options, operator } = filter;
+    const { id, label, columns, type, options, operator, isLoading, size } =
+      filter;
 
     const initialValue = String(simpleFilter?.[id])?.split('||')[2];
 
@@ -88,6 +89,8 @@ const FilterSubmodule: FC<Props> = ({
       options,
       operator,
       value,
+      isLoading,
+      size,
       onChange: (val: string | null) => onFilterChange(id, val, true),
       ...(type === 'text' && {
         onChange: (val: string | null) => onFilterChange(id, val, false),

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -13,6 +13,7 @@ import { TableProps as InnerTableProps } from '../../components/Table/Table';
 import Text from '../../components/Text';
 import TableSubmodule, {
   StyleDefinition,
+  TableSubmoduleProps,
 } from '../../components/submodules/Table';
 import DrawerFormSubmodule from '../../components/submodules/DrawerForm';
 import ModalFormSubmodule from '../../components/submodules/ModalForm';
@@ -32,6 +33,7 @@ interface TableProps {
   searchParam?: string;
   hideActionsColumn?: boolean;
   reordable?: boolean;
+  filters?: TableSubmoduleProps['filters'];
 }
 
 interface FormProps {


### PR DESCRIPTION
### Solves
Implements reordable filters in Crud Module

### How to use
CrudModule now accepts a prop called `filters` which is an array of objects. Each object represents a filter.
The object should have the same proerties from the Filter type but also an `operator` param which will be used to filter the data.

``` Typescript
<CrudModule
  ...
  filters: [
    {
      id: "fullName",
      label: "Full Name",
      operator: "contL",
      type: "text",
      columns: 4,
    },
    {
      id: "userType",
      label: "Select",
      operator: "eq",
      type: "select",
      columns: 4,
      options: [
        {
          label: "SCHOOL STAFF",
          value: "SCHOOL_STAFF",
        },
        {
          label: "STUDENT",
          value: "STUDENT",
        },
        {
          label: "PARENT",
          value: "PARENT",
        },
      ],
    },
    {
      id: "autocomplete",
      label: "Autocomplete",
      operator: "eq",
      type: "autocomplete",
      columns: 4,
      isLoading: true,
      options: [
        {
          label: "Test",
          value: "test",
        },
        {
          label: "Test2",
          value: "test2",
        },
      ],
    },
  ],
/>
```

### Preview

![Screenshot 2024-02-10 134227](https://github.com/conceptadev/rockets-react/assets/32578927/248150c7-998c-43ef-9e24-a86f6490d39e)
