### PR TITLE
fix: change filter id and standardize component pattern

### DIFF
--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -60,7 +60,6 @@ const renderComponent = (filter: FilterType) => {
     case 'autocomplete': {
       return (
         <AutocompleteField
-          key={filter?.defaultValue?.value}
           fullWidth
           size={filter.size ?? 'small'}
           options={filter.options}
@@ -124,7 +123,7 @@ const Filter = (props: FilterProps) => {
   return (
     <Box display="flex" width="100%">
       <Grid container spacing={2} {...rest}>
-        {filterOrder.map((filter, index) => {
+        {filterOrder.map((filter) => {
           const filterIndex = filters.findIndex((f) => f.id === filter.id);
           if (filterIndex === -1) {
             return null;
@@ -137,7 +136,7 @@ const Filter = (props: FilterProps) => {
 
           return (
             <Grid
-              key={`filter-${index}`}
+              key={`filter-${filter.id}`}
               item
               xs={12}
               md={currentFilter.columns || 12}

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -52,7 +52,7 @@ interface SortableItemProps {
   labelId: string;
 }
 
-function SortableItem(props: SortableItemProps) {
+const SortableItem = (props: SortableItemProps) => {
   const { id, checked, label, handleToggle, labelId } = props;
 
   const { attributes, listeners, setNodeRef, transform, transition } =
@@ -86,7 +86,7 @@ function SortableItem(props: SortableItemProps) {
       </ListItem>
     </div>
   );
-}
+};
 
 const OrderableDropDown = ({
   list,


### PR DESCRIPTION
### About

This PR adds an unique identifier to the key of the filter. We can't use the `index` of the item in the array as unique identifier because since we're changing the orders of the items. Let's say that we have two filter: 1) name, 2) email. If we use the `index` for the key prop and then change move email to the first element of the array then `React` will infer wrong props in both fields.
This is also the reason why `Autocomplete` was not "persisting" the state visually.