### PR TITLE
feat: add renderTableCell to crud modules

### DIFF
--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import type {
+  CustomTableCell,
   HeaderProps,
   RowProps,
   TableQueryStateProps,
 } from '../../Table/types';
 
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import {
   Box,
   Button,
@@ -58,8 +59,9 @@ export type StyleDefinition = {
   [key: string]: SxProps<Theme>;
 };
 
-type TableSchemaItem = HeaderProps & {
+export type TableSchemaItem = HeaderProps & {
   format?: (data: unknown) => string | number;
+  renderTableCell?: (data: unknown) => CustomTableCell;
 };
 
 export interface TableSubmoduleProps {
@@ -150,6 +152,10 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
 
         if (schemaItem.format) {
           newData[key] = schemaItem.format(data);
+        }
+
+        if (schemaItem.renderTableCell) {
+          newData[key] = schemaItem.renderTableCell(data);
         }
       });
 

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -2,7 +2,10 @@ import React, { PropsWithChildren } from 'react';
 
 import type { RJSFSchema, UiSchema, CustomValidator } from '@rjsf/utils';
 
-import type { HeaderProps } from '../../components/Table/types';
+import type {
+  CustomTableCell,
+  HeaderProps,
+} from '../../components/Table/types';
 
 import { useMemo, useState } from 'react';
 import { Box } from '@mui/material';
@@ -23,6 +26,7 @@ type SelectedRow = Record<string, unknown> | null;
 
 type TableSchemaItem = HeaderProps & {
   format?: (data: unknown) => string | number;
+  renderTableCell?: (data: unknown) => CustomTableCell;
 };
 
 interface TableProps {

--- a/packages/react-material-ui/src/modules/users/constants.ts
+++ b/packages/react-material-ui/src/modules/users/constants.ts
@@ -1,9 +1,9 @@
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
-import { HeaderProps } from 'components/Table/types';
 import { CustomTextFieldWidget } from '../../styles/CustomWidgets';
 import { FilterDetails } from 'components/submodules/Filter';
+import { TableSchemaItem } from 'components/submodules/Table';
 
-export const headers: HeaderProps[] = [
+export const headers: TableSchemaItem[] = [
   {
     id: 'id',
     label: 'ID',


### PR DESCRIPTION
### About

This PR adds the ability to pass a function `renderTableCell` for a given header. This function has the following signature:

```
 renderTableCell?: (data: unknown) => CustomTableCell;
```

### Usage example

```
...
 {
            id: "fullName",
            label: "Full name",
            renderTableCell: data => ({
              component: (
                <div
                  style={{
                    background: "red",
                  }}
                >
                  {data}
                </div>
              ),
            }),
          },
...

```