### PR TITLE
feat: add password strength component

### DIFF
--- a/packages/react-material-ui/src/components/SchemaForm/utils/mapAdvancedProperties.ts
+++ b/packages/react-material-ui/src/components/SchemaForm/utils/mapAdvancedProperties.ts
@@ -20,10 +20,10 @@ const fieldTypesMap: Record<string, JSONSchema7TypeName> = {
   switch: 'boolean',
 };
 
-export function mapAdvancedProperties(
+export const mapAdvancedProperties = (
   _schema?: JSONSchema7,
   _advancedProperties?: Record<string, AdvancedProperty>,
-): JSONSchema7['properties'] {
+): JSONSchema7['properties'] => {
   if (!_schema?.properties || typeof _schema?.properties !== 'object') return;
 
   const schemaEntries = Object.entries(_schema?.properties);
@@ -77,4 +77,4 @@ export function mapAdvancedProperties(
     });
 
   return Object.fromEntries(overridenProperties);
-}
+};

--- a/packages/react-material-ui/src/components/SchemaForm/utils/mapEnumToCheckbox.ts
+++ b/packages/react-material-ui/src/components/SchemaForm/utils/mapEnumToCheckbox.ts
@@ -2,9 +2,9 @@ import { JSONSchema7Definition } from 'json-schema';
 
 import { AdvancedProperty } from '../types';
 
-export function mapEnumToCheckbox(
+export const mapEnumToCheckbox = (
   advancedProperty: AdvancedProperty,
-): JSONSchema7Definition | JSONSchema7Definition[] | undefined {
+): JSONSchema7Definition | JSONSchema7Definition[] | undefined => {
   if (!advancedProperty.options) return;
 
   const isEnum = advancedProperty.options.every(
@@ -26,4 +26,4 @@ export function mapEnumToCheckbox(
           ),
         }),
   };
-}
+};

--- a/packages/react-material-ui/src/components/SchemaForm/utils/mapEnumToSchema.ts
+++ b/packages/react-material-ui/src/components/SchemaForm/utils/mapEnumToSchema.ts
@@ -1,11 +1,11 @@
 import { JSONSchema7, JSONSchema7Type, JSONSchema7TypeName } from 'json-schema';
 import { AdvancedProperty } from '../types';
 
-export function mapEnumToSchema(
+export const mapEnumToSchema = (
   type: JSONSchema7TypeName,
   enumList: JSONSchema7Type[],
   advancedProperty?: AdvancedProperty,
-): JSONSchema7['oneOf'] {
+): JSONSchema7['oneOf'] => {
   return enumList.map((enumListItem) => {
     const option = advancedProperty?.options?.find((option) => {
       if (typeof option === 'object') {
@@ -28,4 +28,4 @@ export function mapEnumToSchema(
 
     return { type, title, const: value };
   });
-}
+};

--- a/packages/react-material-ui/src/components/SchemaForm/utils/mapWidgetType.ts
+++ b/packages/react-material-ui/src/components/SchemaForm/utils/mapWidgetType.ts
@@ -14,11 +14,11 @@ import {
   CustomTextFieldWidget,
 } from '../../../styles/CustomWidgets';
 
-export function mapWidgetType(
+export const mapWidgetType = (
   propertyKey: string,
   schema: JSONSchema7,
   advancedProperties?: Record<string, AdvancedProperty>,
-) {
+) => {
   const widgetTypes: Record<string, FC<WidgetProps>> = {
     string: CustomTextFieldWidget,
     email: CustomEmailFieldWidget,
@@ -35,4 +35,4 @@ export function mapWidgetType(
   } else {
     return;
   }
-}
+};

--- a/packages/react-material-ui/src/components/SchemaForm/utils/mergeFormData.ts
+++ b/packages/react-material-ui/src/components/SchemaForm/utils/mergeFormData.ts
@@ -1,10 +1,10 @@
 import { JSONSchema7 } from 'json-schema';
 import { SchemaFormProps } from '../SchemaForm';
 
-export function mergeFormData(
+export const mergeFormData = (
   schema: JSONSchema7,
   formData: SchemaFormProps['formData'],
-) {
+) => {
   if (schema?.properties && typeof schema.properties === 'object') {
     const mergedFormData = {
       ...formData,
@@ -29,4 +29,4 @@ export function mergeFormData(
   }
 
   return null;
-}
+};

--- a/packages/react-material-ui/src/components/SchemaForm/utils/uiSchemaGenerator.ts
+++ b/packages/react-material-ui/src/components/SchemaForm/utils/uiSchemaGenerator.ts
@@ -3,10 +3,10 @@ import { UiSchema } from '@rjsf/utils';
 import { mapWidgetType } from './mapWidgetType';
 import { SchemaFormProps } from '../SchemaForm';
 
-export function uiSchemaGenerator(
+export const uiSchemaGenerator = (
   schema: JSONSchema7,
   advancedProperties: SchemaFormProps['advancedProperties'],
-): Record<string, UiSchema> {
+): Record<string, UiSchema> => {
   let uiSchema: Record<string, UiSchema> = {};
 
   if (!schema?.properties || typeof schema.properties !== 'object')
@@ -20,4 +20,4 @@ export function uiSchemaGenerator(
   });
 
   return uiSchema;
-}
+};

--- a/packages/react-material-ui/src/components/TextField/PasswordStrength.tsx
+++ b/packages/react-material-ui/src/components/TextField/PasswordStrength.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode } from 'react';
+import { Box, Typography } from '@mui/material';
+import PasswordStrengthBar, {
+  PasswordStrengthBarVariants,
+} from './PasswordStrengthBar';
+
+type PasswordStrengthProps = {
+  passwordRuleVariant: PasswordStrengthBarVariants;
+  passwordStrengthText: string;
+  renderStrengthBar?: (
+    variant: PasswordStrengthBarVariants,
+    text: string,
+  ) => ReactNode;
+};
+
+const PasswordStrength = ({
+  passwordRuleVariant,
+  passwordStrengthText,
+  renderStrengthBar,
+}: PasswordStrengthProps) => {
+  if (renderStrengthBar) {
+    return <>{renderStrengthBar(passwordRuleVariant, passwordStrengthText)}</>;
+  }
+
+  return (
+    <Box mt={1}>
+      <Box display="flex" gap={2}>
+        {[...Array(4)].map((_, index) => (
+          <PasswordStrengthBar
+            key={`password-bar-${index}`}
+            variant={passwordRuleVariant}
+          />
+        ))}
+      </Box>
+
+      <Typography textAlign="end" color="grey.400" variant="subtitle2" mt={0.5}>
+        {passwordStrengthText}
+      </Typography>
+    </Box>
+  );
+};
+
+export default PasswordStrength;

--- a/packages/react-material-ui/src/components/TextField/PasswordStrengthBar.tsx
+++ b/packages/react-material-ui/src/components/TextField/PasswordStrengthBar.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box } from '@mui/material';
+
+const VARIANT_COLOR_MAPPING = {
+  veryWeak: 'lightgray',
+  weak: 'red',
+  medium: 'yellow',
+  great: 'green',
+};
+
+export enum PasswordStrengthBarVariants {
+  VeryWeak = 'veryWeak',
+  Weak = 'weak',
+  Medium = 'medium',
+  Great = 'great',
+}
+
+export type PasswordStrengthBarProps = {
+  variant: PasswordStrengthBarVariants;
+};
+
+const PasswordStrengthBar = ({
+  variant = PasswordStrengthBarVariants.VeryWeak,
+}: PasswordStrengthBarProps) => {
+  return (
+    <Box
+      sx={{
+        height: '4px',
+        background: VARIANT_COLOR_MAPPING[variant],
+        borderRadius: 1,
+        width: '100%',
+      }}
+    />
+  );
+};
+
+export default PasswordStrengthBar;

--- a/packages/react-material-ui/src/components/TextField/PasswordStrengthRules.tsx
+++ b/packages/react-material-ui/src/components/TextField/PasswordStrengthRules.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode } from 'react';
+import { Box, FormHelperText } from '@mui/material';
+import { PasswordRule } from './constants';
+
+type PasswordStrengthRulesProps = {
+  name: string;
+  value: unknown;
+  rules: PasswordRule[];
+  renderRulesText?: (
+    name: string,
+    value: string,
+    rules: PasswordRule[],
+  ) => ReactNode;
+};
+
+const PasswordStrengthRules = ({
+  name,
+  value,
+  rules,
+  renderRulesText,
+}: PasswordStrengthRulesProps) => {
+  if (renderRulesText) {
+    return <>{renderRulesText(name, value as string, rules)}</>;
+  }
+
+  return (
+    <Box mt={2}>
+      <FormHelperText
+        sx={(theme) => ({
+          color: theme.palette.common.black,
+        })}
+      >
+        Password should contain at least:
+      </FormHelperText>
+      {rules?.map((rule) => (
+        <FormHelperText
+          id={name}
+          sx={(theme) => ({
+            color:
+              value && (value as string).match(rule.pattern)
+                ? theme.palette.success.main
+                : theme.palette.common.black,
+          })}
+        >
+          {rule.label}
+        </FormHelperText>
+      ))}
+    </Box>
+  );
+};
+
+export default PasswordStrengthRules;

--- a/packages/react-material-ui/src/components/TextField/constants.ts
+++ b/packages/react-material-ui/src/components/TextField/constants.ts
@@ -1,0 +1,43 @@
+export const LENGTH_REGEX = new RegExp(/.{8,}$/);
+export const UPPERCASE_REGEX = new RegExp(/.*[A-Z]/);
+export const LOWERCASE_REGEX = new RegExp(/.*[a-z]/);
+export const NUMBER_REGEX = new RegExp(/.*\d/);
+export const SPECIAL_CHARS_REGEX = new RegExp(
+  /.*[!@#$%^&*()_+\-=\\[\]{};':"\\|,.<>\\/?]/,
+);
+
+export const PASSWORD_MATCH_SCORE = [0, 2, 3, 5];
+export const PASSWORD_MATCH_TEXT = ['Very weak', 'Weak', 'Medium', 'Great'];
+
+export const PASSWORD_MATCH_RULES = {
+  text: PASSWORD_MATCH_TEXT,
+  score: PASSWORD_MATCH_SCORE,
+};
+
+export type PasswordRule = {
+  label: string;
+  pattern: RegExp;
+};
+
+export const PASSWORD_DEFAULT_RULES: PasswordRule[] = [
+  {
+    label: '8 characters',
+    pattern: LENGTH_REGEX,
+  },
+  {
+    label: '1 Alpha Upper character',
+    pattern: UPPERCASE_REGEX,
+  },
+  {
+    label: '1 Alpha Lower character',
+    pattern: LOWERCASE_REGEX,
+  },
+  {
+    label: '1 Numeric character',
+    pattern: NUMBER_REGEX,
+  },
+  {
+    label: '1 Special character (Example: "@", "#", "*")',
+    pattern: SPECIAL_CHARS_REGEX,
+  },
+];

--- a/packages/react-material-ui/src/components/TextField/utils.ts
+++ b/packages/react-material-ui/src/components/TextField/utils.ts
@@ -1,0 +1,41 @@
+import { PasswordStrengthBarVariants } from './PasswordStrengthBar';
+import { PasswordStrengthConfig } from './TextField';
+import { PASSWORD_DEFAULT_RULES, PasswordRule } from './constants';
+
+export const validatePasswordScore = (
+  password: string,
+  // Fine to use `PASSWORD_DEFAULT_RULES` and `PASSWORD_MATCH_RULES` because this function is
+  // supposed to be used outside of the component
+  rules: PasswordRule[] = PASSWORD_DEFAULT_RULES,
+  minValidationScore = PASSWORD_DEFAULT_RULES.length,
+) => {
+  const score = getPasswordScore(password, rules);
+
+  return score >= minValidationScore;
+};
+
+export const getPasswordScore = (password: string, rules: PasswordRule[]) => {
+  return rules.filter((rule) => password.match(rule.pattern)).length;
+};
+
+export const getPasswordMatchInfo = (
+  score: number,
+  matchRules: PasswordStrengthConfig['matchRules'],
+): [string, PasswordStrengthBarVariants] => {
+  const variants = Object.values(PasswordStrengthBarVariants);
+
+  if (score === 0) return [matchRules.text[0], variants[0]];
+
+  const scoreIndex = matchRules.score.findIndex((item, index) => {
+    return item >= score || score < matchRules.score?.[index + 1];
+  });
+
+  if (scoreIndex === matchRules.score.length) {
+    return [
+      matchRules.text[matchRules.text.length - 1],
+      variants[matchRules.text.length - 1],
+    ];
+  }
+
+  return [matchRules.text[scoreIndex], variants[scoreIndex]];
+};

--- a/packages/react-material-ui/src/styles/CustomWidgets/CustomPasswordFieldWidget.tsx
+++ b/packages/react-material-ui/src/styles/CustomWidgets/CustomPasswordFieldWidget.tsx
@@ -2,8 +2,19 @@ import React from 'react';
 import { WidgetProps } from '@rjsf/utils';
 import CustomTextFieldWidget from './CustomTextFieldWidget';
 
-const CustomPasswordFieldWidget = (props: WidgetProps) => (
-  <CustomTextFieldWidget {...props} type="password" />
-);
+const CustomPasswordFieldWidget = (props: WidgetProps) => {
+  const { uiSchema } = props;
+
+  const passwordStrengthConfig = uiSchema?.['ui:passwordStrengthConfig'];
+
+  return (
+    <CustomTextFieldWidget
+      {...props}
+      uiSchema={uiSchema}
+      passwordStrengthConfig={passwordStrengthConfig}
+      type="password"
+    />
+  );
+};
 
 export default CustomPasswordFieldWidget;


### PR DESCRIPTION
## About

This PR implements the password strength components inside the TextField. The password strength features can be used both directly on TextField or through CustomPasswordFieldWidget.
We use defaults for the password rules, score validation and texts, but everything piece can be customized either passing a render function or passing different rule values.

## How to use it

By default, the password strength is hidden in the TextField component. If we want to use it, we must explicitly tell the component to render it. Here are the new props that TextField accepts.

```
export type PasswordStrengthConfig = {
  hideRulesText?: boolean;
  hideStrengthBar?: boolean;
  rules?: PasswordRule[];
  matchRules?: {
    text: string[];
    score: number[];
  };
  renderStrengthBar?: (
    variant: PasswordStrengthBarVariants,
    text: string,
  ) => ReactNode;
  renderRulesText?: (
    name: string,
    value: string,
    rules: PasswordRule[],
  ) => ReactNode;
};
```

### hideRulesText

default: true

Hides the rules of the password field.

### hideStrengthBar

default: true

Hides the strength bar of the password field.

### rules

default: PASSWORD_DEFAULT_RULES

An object that contains the rules that will generate the password score . This object should contain a `label` to render in the screen and a RegEx `pattern` to match against. Example:

```
...
[
   {
      label: '8 characters',
      pattern: LENGTH_REGEX
]
...
```

### matchRules

An object containing the rules to determine wether the password score matches what's expected and what to render when it matches. This object should contain two arrays: one with the match score and one with the match text. Example:


```
...
// The password would be "Very Weak" when score is equal 0
// The password would be "Weak" when score is equal 2
// The password would be "Medium" when score is between 3 and 5
// The password would be "Great" when score is equal 5
export const PASSWORD_MATCH_SCORE = [0, 2, 3, 5];
export const PASSWORD_MATCH_TEXT = ['Very weak', 'Weak', 'Medium', 'Great'];

export const PASSWORD_MATCH_RULES = {
  text: PASSWORD_MATCH_TEXT,
  score: PASSWORD_MATCH_SCORE,
};
...
```

### renderStrengthBar

A function that returns a ReactNode. It receives the current variant and its corresponding text and should output a renderable element.

### renderRulesText

A function that returns a ReactNode. It receives the current name, value and the rules. Should output a renderable element.

## Usage in React JsonSchema Form

We can pass the same configuration in for a CustomPasswordFieldWidget using the uiSchema property `ui:passwordStrengthConfig`.

It also exports a function called `validatePasswordScore` as a helper to validate the score of the password when submitting a form.
The `validatePasswordScore` function accepts three arguments, with the last two optional. The first argument is the password to validate against. The last two are `rules` and `minValidationScore`. By default, it uses the `PASSWORD_DEFAULT_RULES` to calculate the results, but if you passed custom rules you should pass whatever that is to this function so it can properly validate the score.
