### PR TITLE
feat: fix format function bug, allow format to return react node

### DIFF
--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -2,11 +2,6 @@ import React, { PropsWithChildren } from 'react';
 
 import type { RJSFSchema, UiSchema, CustomValidator } from '@rjsf/utils';
 
-import type {
-  CustomTableCell,
-  HeaderProps,
-} from '../../components/Table/types';
-
 import { useMemo, useState } from 'react';
 import { Box } from '@mui/material';
 
@@ -24,13 +19,8 @@ type Action = 'creation' | 'edit' | 'details' | null;
 
 type SelectedRow = Record<string, unknown> | null;
 
-type TableSchemaItem = HeaderProps & {
-  format?: (data: unknown) => string | number;
-  renderTableCell?: (data: unknown, rowData: unknown) => CustomTableCell;
-};
-
 interface TableProps {
-  tableSchema: TableSchemaItem[];
+  tableSchema: TableSubmoduleProps['tableSchema'];
   tableProps?: InnerTableProps;
   tableTheme?: StyleDefinition;
   hideActionsColumn?: boolean;


### PR DESCRIPTION
### Solves

[Crud Module Format Improvements](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1328)

This MR does this and that...
- Fixes the tableRows map function, to allow to use format for id's that don't exist in the row data
- Allow the tableRows format to return a ReactNode


### Preview
![Screenshot 2024-03-04 174108](https://github.com/conceptadev/rockets-react/assets/32578927/8ca209c8-e86d-4583-9a13-37c0cb4bf718)
