### PR TITLE
Change layout of filters and actions on Filter submodule

### DIFF
--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -149,7 +149,7 @@ const Filter = (props: FilterProps) => {
           );
         })}
       </Grid>
-      <Box>
+      <Box ml={2}>
         <OrderableDropDown
           icon={<FilterAlt />}
           list={filterOrder}

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -154,7 +154,6 @@ const Filter = (props: FilterProps) => {
           icon={<FilterAlt />}
           list={filterOrder}
           setList={setFilterOrder}
-          text="Filter Settings"
         />
       </Box>
     </Box>

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -154,6 +154,7 @@ const Filter = (props: FilterProps) => {
           icon={<FilterAlt />}
           list={filterOrder}
           setList={setFilterOrder}
+          text="Filter Settings"
         />
       </Box>
     </Box>

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -5,8 +5,8 @@ import ListItem from '@mui/material/ListItem';
 
 import {
   Box,
+  Button,
   Checkbox,
-  IconButton,
   ListItemAvatar,
   ListItemButton,
   ListItemText,
@@ -146,13 +146,20 @@ const OrderableDropDown = ({
 
   return (
     <Box>
-      <IconButton
+      <Button
         onClick={(event: React.MouseEvent<HTMLElement>) => {
           setAnchorEl(event.currentTarget);
         }}
+        startIcon={icon}
+        variant="outlined"
+        sx={{
+          textTransform: 'capitalize',
+          color: '#374151',
+          borderColor: '#374151',
+        }}
       >
-        {icon}
-      </IconButton>
+        Settings
+      </Button>
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <DndContext
           sensors={sensors}

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -42,6 +42,7 @@ interface Props {
   list: ListItem[];
   icon?: ReactNode;
   setList: React.Dispatch<React.SetStateAction<ListItem[]>>;
+  text?: string;
 }
 
 interface SortableItemProps {
@@ -97,6 +98,7 @@ const OrderableDropDown = ({
   list,
   setList,
   icon = <SettingsSuggest />,
+  text,
 }: Props) => {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -156,9 +158,10 @@ const OrderableDropDown = ({
           textTransform: 'capitalize',
           color: '#374151',
           borderColor: '#374151',
+          textWrap: 'nowrap',
         }}
       >
-        Settings
+        {text}
       </Button>
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <DndContext

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
   Checkbox,
+  IconButton,
   ListItemAvatar,
   ListItemButton,
   ListItemText,
@@ -148,21 +149,31 @@ const OrderableDropDown = ({
 
   return (
     <Box>
-      <Button
-        onClick={(event: React.MouseEvent<HTMLElement>) => {
-          setAnchorEl(event.currentTarget);
-        }}
-        startIcon={icon}
-        variant="outlined"
-        sx={{
-          textTransform: 'capitalize',
-          color: '#374151',
-          borderColor: '#374151',
-          textWrap: 'nowrap',
-        }}
-      >
-        {text}
-      </Button>
+      {text ? (
+        <Button
+          onClick={(event: React.MouseEvent<HTMLElement>) => {
+            setAnchorEl(event.currentTarget);
+          }}
+          startIcon={icon}
+          variant="outlined"
+          sx={{
+            textTransform: 'capitalize',
+            color: '#374151',
+            borderColor: '#374151',
+            textWrap: 'nowrap',
+          }}
+        >
+          {text}
+        </Button>
+      ) : (
+        <IconButton
+          onClick={(event: React.MouseEvent<HTMLElement>) => {
+            setAnchorEl(event.currentTarget);
+          }}
+        >
+          {icon}
+        </IconButton>
+      )}
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <DndContext
           sensors={sensors}

--- a/packages/react-material-ui/src/components/Table/TableColumnOrderable.tsx
+++ b/packages/react-material-ui/src/components/Table/TableColumnOrderable.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 
 import { useTableRoot } from './hooks/useTableRoot';
 import OrderableDropDown, { ListItem } from '../OrderableDropDown';
 
-export const TableColumnOrderable = () => {
+type TableColumnOrderableProps = {
+  text: string;
+  icon?: ReactNode;
+};
+
+export const TableColumnOrderable = ({
+  text,
+  icon,
+}: TableColumnOrderableProps) => {
   const { headers, setHeaders } = useTableRoot();
 
   const [headerOrder, setHeaderOrder] = useState<ListItem[]>(
@@ -20,5 +28,12 @@ export const TableColumnOrderable = () => {
     setHeaders(newOrderedHeaders);
   }, [headerOrder]);
 
-  return <OrderableDropDown list={headerOrder} setList={setHeaderOrder} />;
+  return (
+    <OrderableDropDown
+      list={headerOrder}
+      setList={setHeaderOrder}
+      icon={icon}
+      text={text}
+    />
+  );
 };

--- a/packages/react-material-ui/src/components/Table/TableColumnOrderable.tsx
+++ b/packages/react-material-ui/src/components/Table/TableColumnOrderable.tsx
@@ -6,7 +6,7 @@ import { useTableRoot } from './hooks/useTableRoot';
 import OrderableDropDown, { ListItem } from '../OrderableDropDown';
 
 type TableColumnOrderableProps = {
-  text: string;
+  text?: string;
   icon?: ReactNode;
 };
 

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -232,7 +232,9 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
           justifyContent="space-between"
           sx={{ mb: 2 }}
         >
-          {props.reordable !== false && <Table.ColumnOrderable />}
+          {props.reordable !== false && (
+            <Table.ColumnOrderable text="Table Settings" />
+          )}
           {!props.hideAddButton && (
             <Button
               variant="contained"

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -25,6 +25,7 @@ import {
   Edit as EditIcon,
   Delete as DeleteIcon,
   ChevronRight as ChevronRightIcon,
+  Add as AddIcon,
 } from '@mui/icons-material';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 
@@ -213,11 +214,6 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
 
   return (
     <Box>
-      {!props.hideAddButton && (
-        <Button variant="contained" onClick={props.onAddNew} sx={{ mb: 2 }}>
-          Add new
-        </Button>
-      )}
       <Table.Root
         rows={tableRows}
         headers={tableHeaders}
@@ -228,12 +224,26 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
         updateTableQueryState={props.setTableQueryState}
         {...props.tableRootProps}
       >
-        {(filters || props.reordable !== false) && (
-          <Box display="flex" mb={2} pt={1} justifyContent="flex-end">
-            {filters && <FilterSubmodule />}
-            {props.reordable !== false && <Table.ColumnOrderable />}
-          </Box>
-        )}
+        <Box sx={{ padding: '24px 0' }}>{filters && <FilterSubmodule />}</Box>
+
+        <Box
+          display="flex"
+          alignItems="flex-start"
+          justifyContent="space-between"
+          sx={{ mb: 2 }}
+        >
+          {props.reordable !== false && <Table.ColumnOrderable />}
+          {!props.hideAddButton && (
+            <Button
+              variant="contained"
+              onClick={props.onAddNew}
+              startIcon={<AddIcon />}
+              sx={{ textTransform: 'capitalize' }}
+            >
+              Add new
+            </Button>
+          )}
+        </Box>
 
         <TableContainer sx={tableTheme.tableContainer}>
           <Table.Table

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -225,20 +225,36 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
         {...props.tableRootProps}
       >
         <Box
-          display="flex"
-          alignItems="flex-start"
-          justifyContent="space-between"
-          sx={{ mb: 2 }}
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', lg: 'row' },
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            mb: 2,
+          }}
         >
           {filters && <FilterSubmodule />}
-          <Box display="flex" alignItems="center">
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: { xs: 'space-between', lg: 'initial' },
+              mt: { xs: filters ? 2 : 0, lg: 0 },
+              ml: { xs: 0, lg: 2 },
+              width: { xs: '100%', lg: 'auto' },
+            }}
+          >
             {props.reordable !== false && <Table.ColumnOrderable />}
             {!props.hideAddButton && (
               <Button
                 variant="contained"
                 onClick={props.onAddNew}
                 startIcon={<AddIcon />}
-                sx={{ textTransform: 'capitalize', textWrap: 'nowrap' }}
+                sx={{
+                  textTransform: 'capitalize',
+                  textWrap: 'nowrap',
+                  marginLeft: 2,
+                }}
               >
                 Add new
               </Button>

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -224,27 +224,26 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
         updateTableQueryState={props.setTableQueryState}
         {...props.tableRootProps}
       >
-        <Box sx={{ padding: '24px 0' }}>{filters && <FilterSubmodule />}</Box>
-
         <Box
           display="flex"
           alignItems="flex-start"
           justifyContent="space-between"
           sx={{ mb: 2 }}
         >
-          {props.reordable !== false && (
-            <Table.ColumnOrderable text="Table Settings" />
-          )}
-          {!props.hideAddButton && (
-            <Button
-              variant="contained"
-              onClick={props.onAddNew}
-              startIcon={<AddIcon />}
-              sx={{ textTransform: 'capitalize' }}
-            >
-              Add new
-            </Button>
-          )}
+          {filters && <FilterSubmodule />}
+          <Box display="flex" alignItems="center">
+            {props.reordable !== false && <Table.ColumnOrderable />}
+            {!props.hideAddButton && (
+              <Button
+                variant="contained"
+                onClick={props.onAddNew}
+                startIcon={<AddIcon />}
+                sx={{ textTransform: 'capitalize', textWrap: 'nowrap' }}
+              >
+                Add new
+              </Button>
+            )}
+          </Box>
         </Box>
 
         <TableContainer sx={tableTheme.tableContainer}>

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -9,6 +9,7 @@ import useTable from '../../components/Table/useTable';
 import { TableProps as InnerTableProps } from '../../components/Table/Table';
 import Text from '../../components/Text';
 import TableSubmodule, {
+  TableSubmoduleProps,
   StyleDefinition,
 } from '../../components/submodules/Table';
 import DrawerFormSubmodule from '../../components/submodules/DrawerForm';


### PR DESCRIPTION
Modifications of the Filter submodule placement and grid structure. The idea was to have the top row displaying all inputs/actions related to the filters and the bottom row being related to the table itself and/or actions that modify it.

<img width="1440" alt="Screenshot 2024-03-04 at 18 58 07" src="https://github.com/conceptadev/rockets-react/assets/14320830/77a7a329-f604-49ef-9cf8-c6cb65e0e4cf">
