### PR TITLE
Change how the crud form title prop is displayed

### DIFF
--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -114,6 +114,7 @@ const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
             ...formSchema,
             required: formSchema?.required || [],
             properties: formSchema?.properties || {},
+            title: '',
           }}
           uiSchema={{
             ...formUiSchema,

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -117,7 +117,7 @@ const ModalFormSubmodule = (props: ModalFormSubmoduleProps) => {
 
   return (
     <Dialog open={viewMode !== null} maxWidth="md" fullWidth onClose={onClose}>
-      <DialogTitle>{title}</DialogTitle>
+      <DialogTitle>{formSchema?.title || title}</DialogTitle>
       <IconButton
         aria-label="close"
         onClick={onClose}
@@ -136,6 +136,7 @@ const ModalFormSubmodule = (props: ModalFormSubmoduleProps) => {
             ...formSchema,
             required: formSchema?.required || [],
             properties: formSchema?.properties || {},
+            title: '',
           }}
           uiSchema={formUiSchema}
           validator={validator}


### PR DESCRIPTION
When passing the `title` prop inside the Crud module schema form, the string was being duplicated on top of the form. This PR fixes this issue by displaying the form title string as the modal title.

If no title is passed in the schema, the module title is displayed on top of the form.