### PR TITLE
Refactor structure of TextField component

### DIFF
--- a/packages/react-material-ui/src/components/TextField/TextField.tsx
+++ b/packages/react-material-ui/src/components/TextField/TextField.tsx
@@ -2,9 +2,11 @@ import React, { ReactNode, useState } from 'react';
 import {
   Box,
   BoxProps,
+  FormControl,
   InputAdornment,
-  TextField as MuiTextField,
   TextFieldProps as MuiTextFieldProps,
+  InputProps,
+  OutlinedInput as MuiOutlinedInput,
   TypographyProps,
 } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
@@ -115,6 +117,8 @@ export const TextField = (props: TextFieldProps) => {
     options,
     containerProps,
     labelProps,
+    InputProps,
+    InputLabelProps,
     name,
     passwordStrengthConfig,
     ...rest
@@ -157,37 +161,36 @@ export const TextField = (props: TextFieldProps) => {
 
   return (
     <Box {...containerProps}>
-      {!ishiddenLabel && !!label && typeof label === 'string' && (
-        <FormLabel
+      <FormControl hiddenLabel={label ? true : ishiddenLabel} fullWidth>
+        {!ishiddenLabel && !!label && typeof label === 'string' && (
+          <FormLabel
+            name={name}
+            label={label}
+            required={required}
+            labelProps={labelProps}
+            {...InputLabelProps}
+          />
+        )}
+
+        {!ishiddenLabel && !!label && typeof label !== 'string' && label}
+
+        <MuiOutlinedInput
+          {...(rest as InputProps)}
+          sx={[
+            {
+              marginTop: 0.5,
+              mb: 0,
+              input: { color: 'text.primary' },
+            },
+            ...(Array.isArray(sx) ? sx : [sx]),
+          ]}
+          id={name}
           name={name}
-          label={label}
-          required={required}
-          labelProps={labelProps}
-        />
-      )}
-
-      {!ishiddenLabel && !!label && typeof label !== 'string' && label}
-
-      <MuiTextField
-        {...rest}
-        sx={[
-          {
-            marginTop: 0.5,
-            mb: 0,
-            input: { color: 'text.primary' },
-          },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
-        id={name}
-        name={name}
-        size={size || 'small'}
-        value={value || value === 0 ? value : ''}
-        hiddenLabel={label ? true : ishiddenLabel}
-        label={null}
-        type={isPassword ? (showPassword ? 'text' : 'password') : type}
-        InputProps={{
-          ...(isPassword && {
-            endAdornment: (
+          size={size || 'small'}
+          value={value || value === 0 ? value : ''}
+          type={isPassword ? (showPassword ? 'text' : 'password') : type}
+          endAdornment={
+            isPassword && (
               <InputAdornment position="end">
                 <IconButton
                   aria-label="toggle password visibility"
@@ -198,13 +201,13 @@ export const TextField = (props: TextFieldProps) => {
                   {showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
-            ),
-          }),
-          ...props.InputProps,
-        }}
-        data-testid="text-field"
-        fullWidth
-      />
+            )
+          }
+          data-testid="text-field"
+          fullWidth
+          {...InputProps}
+        />
+      </FormControl>
 
       {isPassword && (
         <>

--- a/packages/react-material-ui/src/components/TextField/TextField.tsx
+++ b/packages/react-material-ui/src/components/TextField/TextField.tsx
@@ -157,78 +157,79 @@ export const TextField = (props: TextFieldProps) => {
 
   return (
     <Box {...containerProps}>
-      <FormControl fullWidth>
-        {!ishiddenLabel && !!label && typeof label === 'string' && (
-          <FormLabel
-            name={name}
-            label={label}
-            required={required}
-            labelProps={labelProps}
-          />
-        )}
-        {!ishiddenLabel && !!label && typeof label != 'string' && label}
+      {/* {!ishiddenLabel && !!label && typeof label != 'string' && label} */}
 
-        <MuiTextField
-          {...rest}
-          sx={[
-            {
-              marginTop: 0.5,
-              mb: 0,
-              input: { color: 'text.primary' },
-            },
-            ...(Array.isArray(sx) ? sx : [sx]),
-          ]}
-          id={name}
-          name={name}
-          size={size || 'small'}
-          value={value || value === 0 ? value : ''}
-          hiddenLabel={label ? true : ishiddenLabel}
-          label={''}
-          fullWidth
-          type={isPassword ? (showPassword ? 'text' : 'password') : type}
-          InputProps={{
-            ...(isPassword && {
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle password visibility"
-                    onClick={togglePassword}
-                    onMouseDown={handleMouseDownPassword}
-                    data-testid="toggle-password-button"
-                  >
-                    {showPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }),
-            ...props.InputProps,
-          }}
-          data-testid="text-field"
-        />
+      <MuiTextField
+        {...rest}
+        sx={[
+          {
+            marginTop: 0.5,
+            mb: 0,
+            input: { color: 'text.primary' },
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+        id={name}
+        name={name}
+        size={size || 'small'}
+        value={value || value === 0 ? value : ''}
+        hiddenLabel={label ? true : ishiddenLabel}
+        label={
+          !ishiddenLabel &&
+          !!label &&
+          typeof label === 'string' && (
+            <FormLabel
+              name={name}
+              label={label}
+              required={required}
+              labelProps={labelProps}
+            />
+          )
+        }
+        fullWidth
+        type={isPassword ? (showPassword ? 'text' : 'password') : type}
+        InputProps={{
+          ...(isPassword && {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={togglePassword}
+                  onMouseDown={handleMouseDownPassword}
+                  data-testid="toggle-password-button"
+                >
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }),
+          ...props.InputProps,
+        }}
+        data-testid="text-field"
+      />
 
-        {isPassword && (
-          <>
-            {!passwordStrengthConfigDefault.hideStrengthBar && (
-              <PasswordStrength
-                passwordRuleVariant={passwordRuleVariant}
-                passwordStrengthText={passwordStrengthText}
-                renderStrengthBar={
-                  passwordStrengthConfigDefault.renderStrengthBar
-                }
-              />
-            )}
+      {isPassword && (
+        <>
+          {!passwordStrengthConfigDefault.hideStrengthBar && (
+            <PasswordStrength
+              passwordRuleVariant={passwordRuleVariant}
+              passwordStrengthText={passwordStrengthText}
+              renderStrengthBar={
+                passwordStrengthConfigDefault.renderStrengthBar
+              }
+            />
+          )}
 
-            {!passwordStrengthConfigDefault.hideRulesText && (
-              <PasswordStrengthRules
-                name={name}
-                value={value}
-                rules={passwordStrengthConfigDefault.rules}
-                renderRulesText={passwordStrengthConfigDefault.renderRulesText}
-              />
-            )}
-          </>
-        )}
-      </FormControl>
+          {!passwordStrengthConfigDefault.hideRulesText && (
+            <PasswordStrengthRules
+              name={name}
+              value={value}
+              rules={passwordStrengthConfigDefault.rules}
+              renderRulesText={passwordStrengthConfigDefault.renderRulesText}
+            />
+          )}
+        </>
+      )}
     </Box>
   );
 };

--- a/packages/react-material-ui/src/components/TextField/TextField.tsx
+++ b/packages/react-material-ui/src/components/TextField/TextField.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useState } from 'react';
 import {
   Box,
   BoxProps,
-  FormControl,
   InputAdornment,
   TextField as MuiTextField,
   TextFieldProps as MuiTextFieldProps,
@@ -150,6 +149,7 @@ export const TextField = (props: TextFieldProps) => {
     value as string,
     passwordStrengthConfigDefault.rules,
   );
+
   const [passwordStrengthText, passwordRuleVariant] = getPasswordMatchInfo(
     passwordScore,
     passwordStrengthConfigDefault.matchRules,
@@ -157,7 +157,16 @@ export const TextField = (props: TextFieldProps) => {
 
   return (
     <Box {...containerProps}>
-      {/* {!ishiddenLabel && !!label && typeof label != 'string' && label} */}
+      {!ishiddenLabel && !!label && typeof label === 'string' && (
+        <FormLabel
+          name={name}
+          label={label}
+          required={required}
+          labelProps={labelProps}
+        />
+      )}
+
+      {!ishiddenLabel && !!label && typeof label !== 'string' && label}
 
       <MuiTextField
         {...rest}
@@ -174,19 +183,7 @@ export const TextField = (props: TextFieldProps) => {
         size={size || 'small'}
         value={value || value === 0 ? value : ''}
         hiddenLabel={label ? true : ishiddenLabel}
-        label={
-          !ishiddenLabel &&
-          !!label &&
-          typeof label === 'string' && (
-            <FormLabel
-              name={name}
-              label={label}
-              required={required}
-              labelProps={labelProps}
-            />
-          )
-        }
-        fullWidth
+        label={null}
         type={isPassword ? (showPassword ? 'text' : 'password') : type}
         InputProps={{
           ...(isPassword && {
@@ -206,6 +203,7 @@ export const TextField = (props: TextFieldProps) => {
           ...props.InputProps,
         }}
         data-testid="text-field"
+        fullWidth
       />
 
       {isPassword && (


### PR DESCRIPTION
This PR fixes issue #69, where multiple instances of `FormControl` were being rendered when the `TextField` component was used.

For this fix, the `MuiTextField` internal component was removed and the props separated into `FormControl`, `FormLabel` and `MuiOutlinedInput`, since `MuiTextField` implements a `FormControl` internally and thus accepts the same props.