### PR TITLE
Adjust auto clean when filter is hidden for Date fields

### DIFF
--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -169,31 +169,15 @@ const Filter = (props: FilterProps) => {
     hiddenItems.forEach((item) => {
       const filterItem = filters.find((filter) => filter.id === item.id);
 
-      if (filterItem && filterItem?.type === 'text' && filterItem?.onChange) {
-        filterItem.onChange('');
-      }
-
       if (
         filterItem &&
-        filterItem?.type === 'text' &&
-        filterItem?.onDebouncedSearchChange
-      ) {
-        filterItem.onDebouncedSearchChange('');
-      }
-
-      if (filterItem && filterItem?.type === 'date' && filterItem?.onChange) {
-        filterItem.onChange(null);
-      }
-
-      if (
-        filterItem &&
-        filterItem?.type === 'date' &&
+        (filterItem?.type === 'text' || filterItem?.type === 'date') &&
         filterItem?.onDebouncedSearchChange
       ) {
         filterItem.onDebouncedSearchChange(null);
       }
 
-      if (filterItem && filterItem?.type !== 'text' && filterItem?.onChange) {
+      if (filterItem && filterItem?.onChange) {
         filterItem?.onChange(null);
       }
     });

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -181,6 +181,18 @@ const Filter = (props: FilterProps) => {
         filterItem.onDebouncedSearchChange('');
       }
 
+      if (filterItem && filterItem?.type === 'date' && filterItem?.onChange) {
+        filterItem.onChange(null);
+      }
+
+      if (
+        filterItem &&
+        filterItem?.type === 'date' &&
+        filterItem?.onDebouncedSearchChange
+      ) {
+        filterItem.onDebouncedSearchChange(null);
+      }
+
       if (filterItem && filterItem?.type !== 'text' && filterItem?.onChange) {
         filterItem?.onChange(null);
       }

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -103,6 +103,8 @@ const renderComponent = (filter: FilterType) => {
           value={filter.value}
           onChange={filter.onChange}
           onDebouncedSearchChange={filter.onDebouncedSearchChange}
+          minDate={filter.minDate}
+          maxDate={filter.maxDate}
         />
       );
 
@@ -159,29 +161,23 @@ export type FilterProps = {
 const Filter = (props: FilterProps) => {
   const { filters, ...rest } = props;
 
+  const resetFilters = (item) => () => {
+    if (item && item?.onDebouncedSearchChange) {
+      item.onDebouncedSearchChange(null);
+    }
+
+    if (item && item?.onChange) {
+      item.onChange(null);
+    }
+  };
+
   const [filterOrder, setFilterOrder] = useState<ListItem[]>(
-    filters.map((filter) => ({ id: filter.id, label: filter.label })),
+    filters.map((filter) => ({
+      id: filter.id,
+      label: filter.label,
+      resetFilters: resetFilters(filter),
+    })),
   );
-
-  useEffect(() => {
-    const hiddenItems = filterOrder.filter((item) => item.hide);
-
-    hiddenItems.forEach((item) => {
-      const filterItem = filters.find((filter) => filter.id === item.id);
-
-      if (
-        filterItem &&
-        (filterItem?.type === 'text' || filterItem?.type === 'date') &&
-        filterItem?.onDebouncedSearchChange
-      ) {
-        filterItem.onDebouncedSearchChange(null);
-      }
-
-      if (filterItem && filterItem?.onChange) {
-        filterItem?.onChange(null);
-      }
-    });
-  }, [filterOrder]);
 
   return (
     <Box

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -36,6 +36,7 @@ export interface ListItem {
   id: string;
   label: string;
   hide?: boolean;
+  resetFilters?: () => void;
   [key: string]: unknown;
 }
 
@@ -140,10 +141,18 @@ const OrderableDropDown = ({
     }
 
     setList((prevState) =>
-      prevState.map((listItem) => ({
-        ...listItem,
-        hide: newChecked.includes(listItem.id) ? false : true,
-      })),
+      prevState.map((listItem) => {
+        const isHidden = newChecked.includes(listItem.id) ? false : true;
+
+        if (isHidden && listItem.resetFilters) {
+          listItem.resetFilters();
+        }
+
+        return {
+          ...listItem,
+          hide: isHidden,
+        };
+      }),
     );
 
     setChecked(newChecked);


### PR DESCRIPTION
The issue is that when a Date filter input is hidden, its value is not removed from the current filter object, which results in the table data not changing and always filtering from a field that does not exist.