### PR TITLE
Save Filter settings on local storage

### DIFF
--- a/packages/react-auth-provider/src/index.tsx
+++ b/packages/react-auth-provider/src/index.tsx
@@ -67,6 +67,8 @@ const AuthProvider = ({
   const doLogout = async () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
+    localStorage.removeItem('filterSettings');
+    localStorage.removeItem('tableSettings');
   };
 
   return (

--- a/packages/react-material-ui/__tests__/Filter.spec.tsx
+++ b/packages/react-material-ui/__tests__/Filter.spec.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import Filter, { FilterType } from '../src/components/Filter/Filter';
 
-const SETTINGS_TABLE_ID = 'testing';
+const SETTINGS_ID = 'testing';
 
 describe('Filter Component', () => {
   const allFilters: FilterType[] = [
@@ -48,7 +48,7 @@ describe('Filter Component', () => {
 
   it('renders textfield component if type is "Text"', () => {
     const { getByPlaceholderText } = render(
-      <Filter filters={[allFilters[0]]} tableId={SETTINGS_TABLE_ID} />,
+      <Filter filters={[allFilters[0]]} settingsId={SETTINGS_ID} />,
     );
 
     const input = getByPlaceholderText('Text Test Placeholder');
@@ -57,7 +57,7 @@ describe('Filter Component', () => {
 
   it('renders autocomplete component if type is "Autocomplete"', () => {
     const { getByRole } = render(
-      <Filter filters={[allFilters[1]]} tableId={SETTINGS_TABLE_ID} />,
+      <Filter filters={[allFilters[1]]} settingsId={SETTINGS_ID} />,
     );
 
     const input = getByRole('combobox');
@@ -66,7 +66,7 @@ describe('Filter Component', () => {
 
   it('renders select component if type is "Select"', () => {
     const { getByLabelText } = render(
-      <Filter filters={[allFilters[2]]} tableId={SETTINGS_TABLE_ID} />,
+      <Filter filters={[allFilters[2]]} settingsId={SETTINGS_ID} />,
     );
 
     const input = getByLabelText('Select Test Label');
@@ -75,7 +75,7 @@ describe('Filter Component', () => {
 
   it('renders array of filters correctly', () => {
     const { container } = render(
-      <Filter filters={allFilters} tableId={SETTINGS_TABLE_ID} />,
+      <Filter filters={allFilters} settingsId={SETTINGS_ID} />,
     );
 
     const inputs = container.querySelectorAll('input');
@@ -95,7 +95,7 @@ describe('Filter Component', () => {
 
   it('renders dropdown button', () => {
     const { queryByTestId } = render(
-      <Filter filters={allFilters} tableId={SETTINGS_TABLE_ID} />,
+      <Filter filters={allFilters} settingsId={SETTINGS_ID} />,
     );
 
     const dropdownButton = queryByTestId('FilterAltIcon');
@@ -104,7 +104,7 @@ describe('Filter Component', () => {
 
   it('opens dropdown button on click', () => {
     const { queryByTestId, queryAllByTestId } = render(
-      <Filter filters={allFilters} tableId={SETTINGS_TABLE_ID} />,
+      <Filter filters={allFilters} settingsId={SETTINGS_ID} />,
     );
 
     const dropdownButton = queryByTestId('FilterAltIcon');
@@ -124,9 +124,7 @@ describe('Filter Component', () => {
       getByPlaceholderText,
       getByRole,
       queryByPlaceholderText,
-    } = render(
-      <Filter filters={[allFilters[0]]} tableId={SETTINGS_TABLE_ID} />,
-    );
+    } = render(<Filter filters={[allFilters[0]]} settingsId={SETTINGS_ID} />);
 
     const textInput = getByPlaceholderText('Text Test Placeholder');
     expect(textInput).toBeInTheDocument();

--- a/packages/react-material-ui/__tests__/Filter.spec.tsx
+++ b/packages/react-material-ui/__tests__/Filter.spec.tsx
@@ -7,6 +7,8 @@ import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import Filter, { FilterType } from '../src/components/Filter/Filter';
 
+const SETTINGS_TABLE_ID = 'testing';
+
 describe('Filter Component', () => {
   const allFilters: FilterType[] = [
     {
@@ -46,7 +48,7 @@ describe('Filter Component', () => {
 
   it('renders textfield component if type is "Text"', () => {
     const { getByPlaceholderText } = render(
-      <Filter filters={[allFilters[0]]} tableId="testing" />,
+      <Filter filters={[allFilters[0]]} tableId={SETTINGS_TABLE_ID} />,
     );
 
     const input = getByPlaceholderText('Text Test Placeholder');
@@ -55,7 +57,7 @@ describe('Filter Component', () => {
 
   it('renders autocomplete component if type is "Autocomplete"', () => {
     const { getByRole } = render(
-      <Filter filters={[allFilters[1]]} tableId="testing" />,
+      <Filter filters={[allFilters[1]]} tableId={SETTINGS_TABLE_ID} />,
     );
 
     const input = getByRole('combobox');
@@ -64,7 +66,7 @@ describe('Filter Component', () => {
 
   it('renders select component if type is "Select"', () => {
     const { getByLabelText } = render(
-      <Filter filters={[allFilters[2]]} tableId="testing" />,
+      <Filter filters={[allFilters[2]]} tableId={SETTINGS_TABLE_ID} />,
     );
 
     const input = getByLabelText('Select Test Label');
@@ -73,7 +75,7 @@ describe('Filter Component', () => {
 
   it('renders array of filters correctly', () => {
     const { container } = render(
-      <Filter filters={allFilters} tableId="testing" />,
+      <Filter filters={allFilters} tableId={SETTINGS_TABLE_ID} />,
     );
 
     const inputs = container.querySelectorAll('input');
@@ -93,7 +95,7 @@ describe('Filter Component', () => {
 
   it('renders dropdown button', () => {
     const { queryByTestId } = render(
-      <Filter filters={allFilters} tableId="testing" />,
+      <Filter filters={allFilters} tableId={SETTINGS_TABLE_ID} />,
     );
 
     const dropdownButton = queryByTestId('FilterAltIcon');
@@ -102,7 +104,7 @@ describe('Filter Component', () => {
 
   it('opens dropdown button on click', () => {
     const { queryByTestId, queryAllByTestId } = render(
-      <Filter filters={allFilters} tableId="testing" />,
+      <Filter filters={allFilters} tableId={SETTINGS_TABLE_ID} />,
     );
 
     const dropdownButton = queryByTestId('FilterAltIcon');
@@ -122,7 +124,9 @@ describe('Filter Component', () => {
       getByPlaceholderText,
       getByRole,
       queryByPlaceholderText,
-    } = render(<Filter filters={[allFilters[0]]} tableId="testing" />);
+    } = render(
+      <Filter filters={[allFilters[0]]} tableId={SETTINGS_TABLE_ID} />,
+    );
 
     const textInput = getByPlaceholderText('Text Test Placeholder');
     expect(textInput).toBeInTheDocument();

--- a/packages/react-material-ui/__tests__/Filter.spec.tsx
+++ b/packages/react-material-ui/__tests__/Filter.spec.tsx
@@ -46,7 +46,7 @@ describe('Filter Component', () => {
 
   it('renders textfield component if type is "Text"', () => {
     const { getByPlaceholderText } = render(
-      <Filter filters={[allFilters[0]]} />,
+      <Filter filters={[allFilters[0]]} tableId="testing" />,
     );
 
     const input = getByPlaceholderText('Text Test Placeholder');
@@ -54,21 +54,27 @@ describe('Filter Component', () => {
   });
 
   it('renders autocomplete component if type is "Autocomplete"', () => {
-    const { getByRole } = render(<Filter filters={[allFilters[1]]} />);
+    const { getByRole } = render(
+      <Filter filters={[allFilters[1]]} tableId="testing" />,
+    );
 
     const input = getByRole('combobox');
     expect(input).toHaveClass('MuiAutocomplete-input');
   });
 
   it('renders select component if type is "Select"', () => {
-    const { getByLabelText } = render(<Filter filters={[allFilters[2]]} />);
+    const { getByLabelText } = render(
+      <Filter filters={[allFilters[2]]} tableId="testing" />,
+    );
 
     const input = getByLabelText('Select Test Label');
     expect(input).toHaveClass('MuiSelect-select');
   });
 
   it('renders array of filters correctly', () => {
-    const { container } = render(<Filter filters={allFilters} />);
+    const { container } = render(
+      <Filter filters={allFilters} tableId="testing" />,
+    );
 
     const inputs = container.querySelectorAll('input');
 
@@ -86,7 +92,9 @@ describe('Filter Component', () => {
   });
 
   it('renders dropdown button', () => {
-    const { queryByTestId } = render(<Filter filters={allFilters} />);
+    const { queryByTestId } = render(
+      <Filter filters={allFilters} tableId="testing" />,
+    );
 
     const dropdownButton = queryByTestId('FilterAltIcon');
     expect(dropdownButton).toBeInTheDocument();
@@ -94,7 +102,7 @@ describe('Filter Component', () => {
 
   it('opens dropdown button on click', () => {
     const { queryByTestId, queryAllByTestId } = render(
-      <Filter filters={allFilters} />,
+      <Filter filters={allFilters} tableId="testing" />,
     );
 
     const dropdownButton = queryByTestId('FilterAltIcon');
@@ -114,7 +122,7 @@ describe('Filter Component', () => {
       getByPlaceholderText,
       getByRole,
       queryByPlaceholderText,
-    } = render(<Filter filters={[allFilters[0]]} />);
+    } = render(<Filter filters={[allFilters[0]]} tableId="testing" />);
 
     const textInput = getByPlaceholderText('Text Test Placeholder');
     expect(textInput).toBeInTheDocument();

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -159,7 +159,7 @@ export type FilterProps = {
     columns?: number;
   }[];
   complementaryActions?: ReactNode;
-  tableId?: string;
+  settingsId?: string;
 } & GridProps;
 
 const Filter = (props: FilterProps) => {
@@ -169,7 +169,7 @@ const Filter = (props: FilterProps) => {
   const [settings, setSettings] = useSettingsStorage({
     key: 'filterSettings',
     user: (auth?.user as { id: string })?.id ?? '',
-    tableId: props.tableId || pathname,
+    settingsId: props.settingsId || pathname,
   });
 
   const resetFilters = (item) => () => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -159,6 +159,7 @@ export type FilterProps = {
     columns?: number;
   }[];
   complementaryActions?: ReactNode;
+  tableId?: string;
 } & GridProps;
 
 const Filter = (props: FilterProps) => {
@@ -168,7 +169,7 @@ const Filter = (props: FilterProps) => {
   const [settings, setSettings] = useSettingsStorage({
     key: 'filterSettings',
     user: (auth?.user as { id: string })?.id ?? '',
-    route: pathname,
+    route: props.tableId || pathname,
   });
 
   const resetFilters = (item) => () => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useState, useEffect } from 'react';
 import { Box, Grid, GridProps } from '@mui/material';
 import { FilterAlt } from '@mui/icons-material';
+import { useAuth } from '@concepta/react-auth-provider';
+import { usePathname } from 'next/navigation';
 
 import SearchField from '../../components/SearchField';
 import AutocompleteField from '../../components/AutocompleteField';
@@ -16,6 +18,10 @@ import { SearchFieldProps } from '../../components/SearchField/SearchField';
 import OrderableDropDown, { ListItem } from '../OrderableDropDown';
 import { DatePickerProps } from '@mui/x-date-pickers';
 import DatePickerField from '../../components/DatePickerField';
+import {
+  handlePageSettingsUpdate,
+  getPageSettings,
+} from '../../utils/settings/storage';
 
 export type FilterVariant = 'text' | 'autocomplete' | 'select' | 'date';
 
@@ -160,6 +166,8 @@ export type FilterProps = {
 
 const Filter = (props: FilterProps) => {
   const { filters, ...rest } = props;
+  const auth = useAuth();
+  const pathname = usePathname();
 
   const resetFilters = (item) => () => {
     if (item && item?.onDebouncedSearchChange) {
@@ -179,6 +187,27 @@ const Filter = (props: FilterProps) => {
       resetFilters: resetFilters(filter),
     })),
   );
+
+  useEffect(() => {
+    handlePageSettingsUpdate({
+      key: 'filterSettings',
+      user: (auth?.user as { id: string })?.id ?? '',
+      route: pathname,
+      list: filterOrder,
+    });
+  }, [filterOrder]);
+
+  useEffect(() => {
+    const filterSettings = getPageSettings({
+      key: 'filterSettings',
+      user: (auth?.user as { id: string })?.id ?? '',
+      route: pathname,
+    });
+
+    if (filterSettings.length) {
+      setFilterOrder(filterSettings);
+    }
+  }, []);
 
   return (
     <Box

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -169,7 +169,7 @@ const Filter = (props: FilterProps) => {
   const [settings, setSettings] = useSettingsStorage({
     key: 'filterSettings',
     user: (auth?.user as { id: string })?.id ?? '',
-    route: props.tableId || pathname,
+    tableId: props.tableId || pathname,
   });
 
   const resetFilters = (item) => () => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -212,13 +212,6 @@ const Filter = (props: FilterProps) => {
 
       return;
     }
-
-    setSettings(
-      filters.map((filter) => ({
-        id: filter.id,
-        hide: Boolean(filter.hide),
-      })),
-    );
   }, []);
 
   return (

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -181,45 +181,43 @@ const Filter = (props: FilterProps) => {
     }
   };
 
-  const [filterOrder, setFilterOrder] = useState<ListItem[]>([]);
+  const [filterOrder, setFilterOrder] = useState<ListItem[]>(
+    filters.map((filter) => ({
+      id: filter.id,
+      label: filter.label,
+      hide: filter.hide,
+      resetFilters: resetFilters(filter),
+    })),
+  );
 
   const handleFilterOrderChange = (list: ListItem[]) => {
     setFilterOrder(list);
     setSettings(list);
   };
 
-  console.log('filter order: ', filterOrder);
-  console.log('settings: ', settings);
-
   useEffect(() => {
     if (settings?.length) {
       setFilterOrder(
-        settings.map((item: ListItem) => ({
-          ...item,
-          hide: filters.find((filter) => filter.id === item.id).hide,
-          resetFilters: resetFilters(
-            filters.find((filter) => filter.id === item.id),
-          ),
-        })),
+        settings.map((item: ListItem) => {
+          const filterItem = filters.find((filter) => filter.id === item.id);
+
+          return {
+            ...item,
+            label: filterItem.label,
+            resetFilters: resetFilters(filterItem),
+          };
+        }),
       );
-    } else {
-      setFilterOrder(
-        filters.map((filter) => ({
-          id: filter.id,
-          label: filter.label,
-          hide: filter.hide,
-          resetFilters: resetFilters(filter),
-        })),
-      );
-      setSettings(
-        filters.map((filter) => ({
-          id: filter.id,
-          label: filter.label,
-          hide: Boolean(filter.hide),
-          resetFilters: resetFilters(filter).toString(),
-        })),
-      );
+
+      return;
     }
+
+    setSettings(
+      filters.map((filter) => ({
+        id: filter.id,
+        hide: Boolean(filter.hide),
+      })),
+    );
   }, []);
 
   return (

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -142,6 +142,8 @@ const OrderableDropDown = ({
 
     setList((prevState) =>
       prevState.map((listItem) => {
+        console.log('list item: ', listItem);
+
         const isHidden = newChecked.includes(listItem.id) ? false : true;
 
         if (isHidden && listItem.resetFilters) {

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, ReactNode } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 import ListItem from '@mui/material/ListItem';
 
 import {
@@ -170,6 +170,10 @@ const OrderableDropDown = ({
       });
     }
   };
+
+  useEffect(() => {
+    setChecked(list.filter((listItem) => !listItem.hide).map((li) => li.id));
+  }, [list]);
 
   return (
     <Box>

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -142,8 +142,6 @@ const OrderableDropDown = ({
 
     setList((prevState) =>
       prevState.map((listItem) => {
-        console.log('list item: ', listItem);
-
         const isHidden = newChecked.includes(listItem.id) ? false : true;
 
         if (isHidden && listItem.resetFilters) {

--- a/packages/react-material-ui/src/components/Table/Table.tsx
+++ b/packages/react-material-ui/src/components/Table/Table.tsx
@@ -2,7 +2,7 @@
 
 import React, { PropsWithChildren } from 'react';
 import { TableProps as MuiTableProps } from '@mui/material';
-import { Table as MuiTable, TableProps as TableStylesProps } from './styles';
+import { Table as MuiTable, TableProps as TableStylesProps } from './Styles';
 
 export type TableProps = {
   variant?: TableStylesProps['variant'];

--- a/packages/react-material-ui/src/components/Table/TableOptions.tsx
+++ b/packages/react-material-ui/src/components/Table/TableOptions.tsx
@@ -9,7 +9,7 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Box from '@mui/material/Box';
 
-import { IconContainer } from './styles';
+import { IconContainer } from './Styles';
 import MenuItem from '@mui/material/MenuItem';
 import { CustomRowOptionsProps, RowProps, SimpleOptionButton } from './types';
 

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -1,10 +1,30 @@
-import { ListItem } from 'components/OrderableDropDown';
+import { useState, useEffect } from 'react';
+
+import { ListItem } from '../components/OrderableDropDown';
 
 type Settings = {
   key: string;
   user: string;
   route: string;
   list: ListItem[];
+};
+
+export const getPageSettings = ({
+  key,
+  user,
+  route,
+}: Omit<Settings, 'list'>) => {
+  const storageItem = JSON.parse(localStorage.getItem(key));
+
+  if (!storageItem) {
+    return;
+  }
+
+  const settingsItem = storageItem.find(
+    (item) => item.user === user && item.route === route,
+  );
+
+  return settingsItem.list || [];
 };
 
 export const handlePageSettingsUpdate = ({
@@ -49,20 +69,23 @@ export const handlePageSettingsUpdate = ({
   localStorage.setItem(key, JSON.stringify(storageItem));
 };
 
-export const getPageSettings = ({
+export const useSettingsStorage = ({
   key,
   user,
   route,
 }: Omit<Settings, 'list'>) => {
-  const storageItem = JSON.parse(localStorage.getItem(key));
+  const [settings, setSettings] = useState(() => {
+    return getPageSettings({ key, user, route });
+  });
 
-  if (!storageItem) {
-    return;
-  }
+  useEffect(() => {
+    handlePageSettingsUpdate({
+      key,
+      user,
+      route,
+      list: settings,
+    });
+  }, [key, settings]);
 
-  const settingsItem = storageItem.find(
-    (item) => item.user === user && item.route === route,
-  );
-
-  return settingsItem.list || [];
+  return [settings, setSettings];
 };

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
 
-import { ListItem } from '../components/OrderableDropDown';
+type ListItem = {
+  id: string;
+  hide: boolean;
+};
 
 type Settings = {
   key: string;
@@ -21,7 +24,7 @@ export const getPageSettings = ({
   }
 
   const settingsItem = storageItem.find(
-    (item) => item.user === user && item.route === route,
+    (item: Settings) => item.user === user && item.route === route,
   );
 
   return settingsItem?.list || [];
@@ -47,7 +50,7 @@ export const handlePageSettingsUpdate = ({
   }
 
   const settingsItemIndex = storageItem.findIndex(
-    (item) => item.user === user && item.route === route,
+    (item: Settings) => item.user === user && item.route === route,
   );
 
   if (settingsItemIndex > -1) {

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -8,14 +8,14 @@ type ListItem = {
 type Settings = {
   key: string;
   user: string;
-  tableId: string;
+  settingsId: string;
   list: ListItem[];
 };
 
 export const getPageSettings = ({
   key,
   user,
-  tableId,
+  settingsId,
 }: Omit<Settings, 'list'>) => {
   const storageItem = JSON.parse(localStorage.getItem(key));
 
@@ -24,7 +24,7 @@ export const getPageSettings = ({
   }
 
   const settingsItem = storageItem.find(
-    (item: Settings) => item.user === user && item.tableId === tableId,
+    (item: Settings) => item.user === user && item.settingsId === settingsId,
   );
 
   return settingsItem?.list || [];
@@ -33,14 +33,14 @@ export const getPageSettings = ({
 export const handlePageSettingsUpdate = ({
   key,
   user,
-  tableId,
+  settingsId,
   list,
 }: Settings) => {
   const storageItem = JSON.parse(localStorage.getItem(key));
 
   const newSettings = {
     user,
-    tableId,
+    settingsId,
     list,
   };
 
@@ -50,7 +50,7 @@ export const handlePageSettingsUpdate = ({
   }
 
   const settingsItemIndex = storageItem.findIndex(
-    (item: Settings) => item.user === user && item.tableId === tableId,
+    (item: Settings) => item.user === user && item.settingsId === settingsId,
   );
 
   if (settingsItemIndex > -1) {
@@ -65,17 +65,17 @@ export const handlePageSettingsUpdate = ({
 export const useSettingsStorage = ({
   key,
   user,
-  tableId,
+  settingsId,
 }: Omit<Settings, 'list'>) => {
   const [settings, setSettings] = useState(() => {
-    return getPageSettings({ key, user, tableId });
+    return getPageSettings({ key, user, settingsId });
   });
 
   useEffect(() => {
     handlePageSettingsUpdate({
       key,
       user,
-      tableId,
+      settingsId,
       list: settings,
     });
   }, [key, settings]);

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -24,7 +24,7 @@ export const getPageSettings = ({
     (item) => item.user === user && item.route === route,
   );
 
-  return settingsItem.list || [];
+  return settingsItem?.list || [];
 };
 
 export const handlePageSettingsUpdate = ({
@@ -35,30 +35,20 @@ export const handlePageSettingsUpdate = ({
 }: Settings) => {
   const storageItem = JSON.parse(localStorage.getItem(key));
 
-  if (!storageItem) {
-    localStorage.setItem(
-      key,
-      JSON.stringify([
-        {
-          user,
-          route,
-          list,
-        },
-      ]),
-    );
+  const newSettings = {
+    user,
+    route,
+    list,
+  };
 
+  if (!storageItem) {
+    localStorage.setItem(key, JSON.stringify([newSettings]));
     return;
   }
 
   const settingsItemIndex = storageItem.findIndex(
     (item) => item.user === user && item.route === route,
   );
-
-  const newSettings = {
-    user,
-    route,
-    list,
-  };
 
   if (settingsItemIndex > -1) {
     storageItem[settingsItemIndex] = newSettings;

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -8,14 +8,14 @@ type ListItem = {
 type Settings = {
   key: string;
   user: string;
-  route: string;
+  tableId: string;
   list: ListItem[];
 };
 
 export const getPageSettings = ({
   key,
   user,
-  route,
+  tableId,
 }: Omit<Settings, 'list'>) => {
   const storageItem = JSON.parse(localStorage.getItem(key));
 
@@ -24,7 +24,7 @@ export const getPageSettings = ({
   }
 
   const settingsItem = storageItem.find(
-    (item: Settings) => item.user === user && item.route === route,
+    (item: Settings) => item.user === user && item.tableId === tableId,
   );
 
   return settingsItem?.list || [];
@@ -33,14 +33,14 @@ export const getPageSettings = ({
 export const handlePageSettingsUpdate = ({
   key,
   user,
-  route,
+  tableId,
   list,
 }: Settings) => {
   const storageItem = JSON.parse(localStorage.getItem(key));
 
   const newSettings = {
     user,
-    route,
+    tableId,
     list,
   };
 
@@ -50,7 +50,7 @@ export const handlePageSettingsUpdate = ({
   }
 
   const settingsItemIndex = storageItem.findIndex(
-    (item: Settings) => item.user === user && item.route === route,
+    (item: Settings) => item.user === user && item.tableId === tableId,
   );
 
   if (settingsItemIndex > -1) {
@@ -65,17 +65,17 @@ export const handlePageSettingsUpdate = ({
 export const useSettingsStorage = ({
   key,
   user,
-  route,
+  tableId,
 }: Omit<Settings, 'list'>) => {
   const [settings, setSettings] = useState(() => {
-    return getPageSettings({ key, user, route });
+    return getPageSettings({ key, user, tableId });
   });
 
   useEffect(() => {
     handlePageSettingsUpdate({
       key,
       user,
-      route,
+      tableId,
       list: settings,
     });
   }, [key, settings]);

--- a/packages/react-material-ui/src/utils/settings/storage.ts
+++ b/packages/react-material-ui/src/utils/settings/storage.ts
@@ -34,18 +34,16 @@ export const handlePageSettingsUpdate = ({
     (item) => item.user === user && item.route === route,
   );
 
+  const newSettings = {
+    user,
+    route,
+    list,
+  };
+
   if (settingsItemIndex > -1) {
-    storageItem[settingsItemIndex] = {
-      user,
-      route,
-      list,
-    };
+    storageItem[settingsItemIndex] = newSettings;
   } else {
-    storageItem.push({
-      user,
-      route,
-      list,
-    });
+    storageItem.push(newSettings);
   }
 
   localStorage.setItem(key, JSON.stringify(storageItem));

--- a/packages/react-material-ui/src/utils/settings/storage.ts
+++ b/packages/react-material-ui/src/utils/settings/storage.ts
@@ -1,0 +1,70 @@
+import { ListItem } from 'components/OrderableDropDown';
+
+type Settings = {
+  key: string;
+  user: string;
+  route: string;
+  list: ListItem[];
+};
+
+export const handlePageSettingsUpdate = ({
+  key,
+  user,
+  route,
+  list,
+}: Settings) => {
+  const storageItem = JSON.parse(localStorage.getItem(key));
+
+  if (!storageItem) {
+    localStorage.setItem(
+      key,
+      JSON.stringify([
+        {
+          user,
+          route,
+          list,
+        },
+      ]),
+    );
+
+    return;
+  }
+
+  const settingsItemIndex = storageItem.findIndex(
+    (item) => item.user === user && item.route === route,
+  );
+
+  if (settingsItemIndex > -1) {
+    storageItem[settingsItemIndex] = {
+      user,
+      route,
+      list,
+    };
+  } else {
+    storageItem.push({
+      user,
+      route,
+      list,
+    });
+  }
+
+  localStorage.setItem(key, JSON.stringify(storageItem));
+};
+
+export const getPageSettings = ({
+  key,
+  user,
+  route,
+}: Omit<Settings, 'list'>) => {
+  const storageItem = JSON.parse(localStorage.getItem(key));
+
+  if (!storageItem) {
+    return;
+  }
+
+  const settingsItem = storageItem.find(
+    (item) => item.user === user && item.route === route,
+  );
+
+  return settingsItem.list || [];
+};


### PR DESCRIPTION
### [Save Filter settings by user and page](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1397)

#### Related to [issue 111](https://github.com/conceptadev/rockets-react/issues/111)

The scope of this PR is to implement persistence for the Filter data on localStorage (for now, the idea is to have this integrated with BE in the future) every time the user changes the settings (toggle and/or change order of filters). To structure the data saved, the `react-auth-provider` and `next/navigation` libs are used, for getting the logged user data and the current route, respectively.

The structure consists of an array of objects, each one representing settings related to a specific user, as follows:

```json
[
   {
      "userId":"USER_ID",
      "settingsId":"SETTINGS_ID",
      "list":"SETTINGS_LIST"
   }
]
```

The array is saved on storage with the `filterSettings` key.

`userId`: unique id of the user logged in;
`settingsId`: prop representing an identifier for the settings object. if no value is passed, the current route is used;
`list`: the current array state of the filters, with each object containing id and hide attributes. is modified every time this list is changed by the user.