### PR TITLE
Save Table settings on local storage

### DIFF
--- a/packages/react-material-ui/__tests__/ComposedTable.spec.tsx
+++ b/packages/react-material-ui/__tests__/ComposedTable.spec.tsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FilterType } from '../src/components/Filter/Filter';
+import { HeaderProps } from '../src/components/Table/types';
+import ComposedTable from '../src/components/ComposedTable';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => {
+    return {
+      replace: jest.fn(),
+    };
+  },
+  useSearchParams: jest.fn(),
+  usePathname: jest.fn(),
+}));
+
+const headers: HeaderProps[] = [
+  {
+    id: 'name',
+    label: 'Name',
+  },
+  {
+    id: 'role',
+    label: 'Role',
+    width: 200,
+  },
+  {
+    id: 'active',
+    label: 'Active',
+  },
+];
+
+const data = [
+  {
+    id: 'johndoe',
+    name: 'John Doe',
+    role: 'Manager',
+    active: true,
+  },
+  {
+    id: 'janedoe',
+    name: 'Jane Doe',
+    role: 'Admin',
+    active: true,
+  },
+  {
+    id: 'jamesdoe',
+    name: 'James Doe',
+    role: 'Manager',
+    active: false,
+  },
+];
+
+describe('ComposedTable Component', () => {
+  const allFilters: FilterType[] = [
+    {
+      id: 'text',
+      label: 'Text',
+      type: 'text',
+      placeholder: 'Text Test Placeholder',
+      onChange: jest.fn(),
+    },
+    {
+      id: 'autocomplete',
+      type: 'autocomplete',
+      options: [
+        {
+          label: 'Autocomplete Test',
+          value: 'autocompleteTest',
+        },
+      ],
+      label: 'Autocomplete Test Label',
+      value: undefined,
+      onChange: jest.fn(),
+      isLoading: false,
+    },
+    {
+      id: 'select',
+      type: 'select',
+      options: [
+        {
+          label: 'Test',
+          value: 'test',
+        },
+      ],
+      label: 'Select Test Label',
+      onChange: jest.fn(),
+    },
+  ];
+
+  it('renders filter inputs when filter prop is passed', () => {
+    const { getByPlaceholderText, getAllByRole, getByRole } = render(
+      <ComposedTable
+        rows={data.map((row) => ({
+          ...row,
+          active: row.active ? 'Active' : 'Inactive',
+        }))}
+        headers={headers}
+        tableQueryState={{}}
+        updateTableQueryState={() => null}
+        total={data.length}
+        pageCount={1}
+        data={data}
+        isPending={false}
+        filters={allFilters}
+        complementaryActions={<button>Action Button</button>}
+      />,
+    );
+
+    const input = getByPlaceholderText('Text Test Placeholder');
+    expect(input).toBeInTheDocument();
+
+    const comboboxInputs = getAllByRole('combobox');
+    expect(comboboxInputs).toHaveLength(3);
+
+    const tableElement = getByRole('table');
+    expect(tableElement).toBeInTheDocument();
+  });
+
+  it('renders only default table when filters prop is empty', () => {
+    const { queryByPlaceholderText, getByRole, getAllByRole } = render(
+      <ComposedTable
+        rows={data.map((row) => ({
+          ...row,
+          active: row.active ? 'Active' : 'Inactive',
+        }))}
+        headers={headers}
+        tableQueryState={{}}
+        updateTableQueryState={() => null}
+        total={data.length}
+        pageCount={1}
+        data={data}
+        isPending={false}
+      />,
+    );
+
+    const textInput = queryByPlaceholderText('Text Test Placeholder');
+    expect(textInput).toBeNull();
+
+    const comboboxInputs = getAllByRole('combobox');
+    expect(comboboxInputs).toHaveLength(1);
+
+    const tableElement = getByRole('table');
+    expect(tableElement).toBeInTheDocument();
+  });
+});

--- a/packages/react-material-ui/__tests__/Filter.spec.tsx
+++ b/packages/react-material-ui/__tests__/Filter.spec.tsx
@@ -46,6 +46,10 @@ describe('Filter Component', () => {
     },
   ];
 
+  beforeEach(() => {
+    localStorage.removeItem('filterSettings');
+  });
+
   it('renders textfield component if type is "Text"', () => {
     const { getByPlaceholderText } = render(
       <Filter filters={[allFilters[0]]} settingsId={SETTINGS_ID} />,

--- a/packages/react-material-ui/src/components/ComposedTable/constants.ts
+++ b/packages/react-material-ui/src/components/ComposedTable/constants.ts
@@ -1,0 +1,49 @@
+import { createTableStyles } from '../Table/utils';
+import { Theme, SxProps } from '@mui/material';
+
+export type StyleDefinition = {
+  root?: SxProps<Theme>;
+  table?: SxProps<Theme>;
+  tableContainer?: SxProps<Theme>;
+  tableHeader?: SxProps<Theme>;
+  tableHeaderRow?: SxProps<Theme>;
+  tableHeaderCell?: SxProps<Theme>;
+  tableBodyRow?: SxProps<Theme>;
+  tableBodyCell?: SxProps<Theme>;
+  [key: string]: SxProps<Theme>;
+};
+
+export const generateTableTheme = (
+  theme: Theme,
+  customTableTheme?: StyleDefinition,
+) =>
+  createTableStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      flex: 1,
+      overflow: 'auto',
+      ...customTableTheme?.root,
+    },
+    table: {
+      height: '100%',
+      ...customTableTheme?.table,
+    },
+    tableContainer: {
+      flex: 1,
+      ...customTableTheme?.tableContainer,
+    },
+    tableHeader: {
+      ...theme.typography.caption,
+      lineHeight: 1,
+      fontWeight: 500,
+      color: theme.palette.grey[500],
+      ...customTableTheme?.tableHeader,
+    },
+    tableHeaderRow: {
+      backgroundColor: '#F9FAFB',
+      textTransform: 'uppercase',
+      ...customTableTheme?.tableHeaderRow,
+    },
+    ...customTableTheme,
+  });

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+
+import type { TableRootProps } from '../Table/TableRoot';
+import type { FilterProps } from '../Filter/Filter';
+
+import {
+  Box,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  useTheme,
+} from '@mui/material';
+import { Settings } from '@mui/icons-material';
+import { useAuth } from '@concepta/react-auth-provider';
+import { usePathname } from 'next/navigation';
+
+import Table from '../Table';
+import { StyleDefinition, generateTableTheme } from './constants';
+import Filter from '../Filter';
+import OrderableDropDown, { ListItem } from '../OrderableDropDown';
+import { useSettingsStorage } from '../../hooks/useSettingsStorage';
+
+export type ComposedTableProps = {
+  data: unknown[];
+  isPending?: boolean;
+  tableTheme?: StyleDefinition;
+} & TableRootProps &
+  FilterProps;
+
+const ComposedTable = (props: ComposedTableProps) => {
+  const theme = useTheme();
+  const tableTheme = generateTableTheme(theme, props.tableTheme);
+
+  const auth = useAuth();
+  const pathname = usePathname();
+  const [settings, setSettings] = useSettingsStorage({
+    key: 'tableSettings',
+    user: (auth?.user as { id: string })?.id ?? '',
+    tableId: props.tableId || pathname,
+  });
+
+  const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
+
+  const handleHeadersOrderChange = (list: ListItem[]) => {
+    setOrderableHeaders(list);
+    setSettings(list);
+  };
+
+  useEffect(() => {
+    if (settings?.length) {
+      setOrderableHeaders(
+        settings.map((item: ListItem) => {
+          const headerItem = props.headers.find(
+            (header) => header.id === item.id,
+          );
+
+          return {
+            ...item,
+            ...headerItem,
+          };
+        }),
+      );
+
+      return;
+    }
+
+    setSettings(
+      props.headers.map((header) => ({
+        id: header.id,
+        hide: Boolean(header.hide),
+      })),
+    );
+  }, []);
+
+  return (
+    <Box>
+      <Table.Root
+        {...props}
+        headers={orderableHeaders}
+        sx={tableTheme.root}
+        key={JSON.stringify(orderableHeaders)}
+      >
+        <Box my={3}>
+          <Filter
+            {...props}
+            complementaryActions={
+              <Box display="flex" gap={2}>
+                <OrderableDropDown
+                  icon={<Settings />}
+                  list={orderableHeaders}
+                  setList={handleHeadersOrderChange}
+                />
+                {props.complementaryActions}
+              </Box>
+            }
+          />
+        </Box>
+        <TableContainer sx={tableTheme.tableContainer}>
+          <Table.Table stickyHeader variant="outlined" sx={tableTheme.table}>
+            <TableHead>
+              <TableRow sx={tableTheme.tableHeaderRow}>
+                <Table.HeaderCells
+                  renderCell={(cell) => (
+                    <Table.HeaderCell cell={cell} sx={tableTheme.tableHeader} />
+                  )}
+                />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {Boolean(!props.isPending && !props.data?.length) && (
+                <TableRow sx={tableTheme.tableBodyRow}>
+                  <TableCell
+                    colSpan={props.headers.length}
+                    sx={{
+                      textAlign: 'center',
+                    }}
+                  >
+                    No records found.
+                  </TableCell>
+                </TableRow>
+              )}
+              <Table.BodyRows
+                renderRow={(row) => (
+                  <Table.BodyRow
+                    row={row}
+                    hasCheckboxes={false}
+                    hover={false}
+                    sx={tableTheme.tableBodyRow}
+                  >
+                    <Table.BodyCell row={row} sx={tableTheme.tableBodyCell} />
+                  </Table.BodyRow>
+                )}
+              />
+            </TableBody>
+          </Table.Table>
+        </TableContainer>
+        <Table.Pagination variant="outlined" />
+      </Table.Root>
+    </Box>
+  );
+};
+
+export default ComposedTable;

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -40,6 +40,10 @@ const ComposedTable = (props: ComposedTableProps) => {
     key: 'tableSettings',
     user: (auth?.user as { id: string })?.id ?? '',
     settingsId: props.settingsId || pathname,
+    list: props.headers.map((header) => ({
+      id: header.id,
+      hide: Boolean(header.hide),
+    })),
   });
 
   const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
@@ -50,7 +54,7 @@ const ComposedTable = (props: ComposedTableProps) => {
   };
 
   useEffect(() => {
-    if (settings?.length) {
+    if (settings.length) {
       setOrderableHeaders(
         settings.map((item: ListItem) => {
           const headerItem = props.headers.find(
@@ -63,8 +67,6 @@ const ComposedTable = (props: ComposedTableProps) => {
           };
         }),
       );
-
-      return;
     }
   }, []);
 

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -39,7 +39,7 @@ const ComposedTable = (props: ComposedTableProps) => {
   const [settings, setSettings] = useSettingsStorage({
     key: 'tableSettings',
     user: (auth?.user as { id: string })?.id ?? '',
-    tableId: props.tableId || pathname,
+    settingsId: props.settingsId || pathname,
   });
 
   const [orderableHeaders, setOrderableHeaders] = useState(props.headers);

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -66,13 +66,6 @@ const ComposedTable = (props: ComposedTableProps) => {
 
       return;
     }
-
-    setSettings(
-      props.headers.map((header) => ({
-        id: header.id,
-        hide: Boolean(header.hide),
-      })),
-    );
   }, []);
 
   return (

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -27,7 +27,7 @@ export type ComposedTableProps = {
   isPending?: boolean;
   tableTheme?: StyleDefinition;
 } & TableRootProps &
-  FilterProps;
+  Partial<FilterProps>;
 
 const ComposedTable = (props: ComposedTableProps) => {
   const theme = useTheme();
@@ -35,6 +35,7 @@ const ComposedTable = (props: ComposedTableProps) => {
 
   const auth = useAuth();
   const pathname = usePathname();
+
   const [settings, setSettings] = useSettingsStorage({
     key: 'tableSettings',
     user: (auth?.user as { id: string })?.id ?? '',
@@ -85,6 +86,7 @@ const ComposedTable = (props: ComposedTableProps) => {
         <Box my={3}>
           <Filter
             {...props}
+            filters={props.filters || []}
             complementaryActions={
               <Box display="flex" gap={2}>
                 <OrderableDropDown

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -206,10 +206,6 @@ const Filter = (props: FilterProps) => {
         settings.map((item: ListItem) => {
           const filterItem = filters.find((filter) => filter.id === item.id);
 
-          if (!filterItem) {
-            return {};
-          }
-
           return {
             ...item,
             label: filterItem.label,

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -169,6 +169,7 @@ const Filter = (props: FilterProps) => {
   const { filters, hasAllOption, ...rest } = props;
   const auth = useAuth();
   const pathname = usePathname();
+
   const [settings, setSettings] = useSettingsStorage({
     key: 'filterSettings',
     user: (auth?.user as { id: string })?.id ?? '',
@@ -204,6 +205,10 @@ const Filter = (props: FilterProps) => {
       setFilterOrder(
         settings.map((item: ListItem) => {
           const filterItem = filters.find((filter) => filter.id === item.id);
+
+          if (!filterItem) {
+            return {};
+          }
 
           return {
             ...item,

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -174,6 +174,10 @@ const Filter = (props: FilterProps) => {
     key: 'filterSettings',
     user: (auth?.user as { id: string })?.id ?? '',
     settingsId: props.settingsId || pathname,
+    list: filters.map((header) => ({
+      id: header.id,
+      hide: Boolean(header.hide),
+    })),
   });
 
   const resetFilters = (item) => () => {
@@ -201,20 +205,18 @@ const Filter = (props: FilterProps) => {
   };
 
   useEffect(() => {
-    if (settings?.length) {
+    if (settings.length) {
       setFilterOrder(
         settings.map((item: ListItem) => {
           const filterItem = filters.find((filter) => filter.id === item.id);
 
           return {
             ...item,
-            label: filterItem.label,
+            ...filterItem,
             resetFilters: resetFilters(filterItem),
           };
         }),
       );
-
-      return;
     }
   }, []);
 

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -276,12 +276,14 @@ const Filter = (props: FilterProps) => {
           gap: { xs: 4, md: 2 },
         }}
       >
-        <OrderableDropDown
-          hasAllOption={hasAllOption}
-          icon={<FilterAlt />}
-          list={filterOrder}
-          setList={handleFilterOrderChange}
-        />
+        {filters.length ? (
+          <OrderableDropDown
+            hasAllOption={hasAllOption}
+            icon={<FilterAlt />}
+            list={filterOrder}
+            setList={handleFilterOrderChange}
+          />
+        ) : null}
         {props.complementaryActions}
       </Box>
     </Box>

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -12,15 +12,11 @@ type Settings = {
   list: ListItem[];
 };
 
-export const getPageSettings = ({
-  key,
-  user,
-  settingsId,
-}: Omit<Settings, 'list'>) => {
+export const getPageSettings = ({ key, user, settingsId, list }: Settings) => {
   const storageItem = JSON.parse(localStorage.getItem(key));
 
   if (!storageItem) {
-    return;
+    return list;
   }
 
   const settingsItem = storageItem.find(
@@ -66,9 +62,10 @@ export const useSettingsStorage = ({
   key,
   user,
   settingsId,
-}: Omit<Settings, 'list'>) => {
+  list,
+}: Settings) => {
   const [settings, setSettings] = useState(() => {
-    return getPageSettings({ key, user, settingsId });
+    return getPageSettings({ key, user, settingsId, list });
   });
 
   useEffect(() => {

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -23,7 +23,7 @@ export const getPageSettings = ({ key, user, settingsId, list }: Settings) => {
     (item: Settings) => item.user === user && item.settingsId === settingsId,
   );
 
-  return settingsItem?.list || [];
+  return settingsItem?.list || list;
 };
 
 export const handlePageSettingsUpdate = ({

--- a/packages/react-material-ui/src/index.ts
+++ b/packages/react-material-ui/src/index.ts
@@ -48,6 +48,8 @@ export { default as SchemaForm } from './components/SchemaForm';
 import FormFieldSkeleton from './components/FormFieldSkeleton';
 export { FormFieldSkeleton };
 
+export { default as ComposedTable } from './components/ComposedTable';
+
 export { default as AuthModule } from './modules/auth';
 export { default as CrudModule } from './modules/crud';
 export { default as UsersModule } from './modules/users';


### PR DESCRIPTION
### [Save Table settings by user and page](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1397)

#### Related to [issue 111](https://github.com/conceptadev/rockets-react/issues/111)

The scope of this PR is to implement persistence for the Table data on localStorage (for now, the idea is to have this integrated with BE in the future) every time the user changes the settings (toggle and/or change order of table columns). To structure the data saved, the `react-auth-provider` and `next/navigation` libs are used, for getting the logged user data and the current route, respectively.

The `ComposedTable` component was created so that the table settings can be present by default on every table instance. This component puts together the `Filter` and `Table` components, allowing the contents and settings handlers to be passed by props. Example of how to instance the `ComposedTable` as follows:

```jsx
<ComposedTable
  rows={rows}
  headers={headers}
  tableQueryState={tableQueryState}
  updateTableQueryState={setTableQueryState}
  total={total}
  pageCount={pageCount}
  data={data}
  isPending={isPending}
  filters={[
    {
      id: 'name',
      label: 'Name',
      type: 'text',
      columns: 5,
    },
    {
      id: 'status',
      label: 'Status',
      type: 'select',
      options: [],
      defaultValue: 'all',
      columns: 3,
      onChange: value => null,
    },
  ]}
  complementaryActions={
    <Button>
      Add New
    </Button>
  }
/>
```

The storage item structure consists of an array of objects, each one representing settings related to a specific user, as follows:

```json
[
   {
      "userId":"USER_ID",
      "tableId":"TABLE_ID",
      "list":"SETTINGS_LIST"
   }
]
```

The array is saved on storage with the `tableSettings` key.

`userId`: unique id of the user logged in;
`tableId`: prop representing which table is modified by the settings. if no value is passed, the current route is used;
`list`: the current array state of the table columns, with each object containing id and hide attributes. is modified every time this list is changed by the user.