### PR TITLE
feat: allow filter to have min items and allow passing render function

### DIFF
--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -167,7 +167,7 @@ export type FilterProps = {
 } & GridProps;
 
 const Filter = (props: FilterProps) => {
-  const { filters,  minimumFilters = 1, hasAllOption, ...rest } = props;
+  const { filters, minimumFilters = 0, hasAllOption, ...rest } = props;
   const auth = useAuth();
   const pathname = usePathname();
 

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -155,17 +155,18 @@ const renderComponent = (filter: FilterType) => {
 
 export type FilterProps = {
   filters: FilterType[];
+  minimumFilters?: number;
   children?: ReactNode;
   additionalGridItems?: {
-    component: ReactNode;
+    component: ReactNode | ((filters: ListItem[]) => ReactNode);
     columns?: number;
   }[];
-  complementaryActions?: ReactNode;
+  complementaryActions?: ReactNode | ((filters: ListItem[]) => ReactNode);
   settingsId?: string;
 } & GridProps;
 
 const Filter = (props: FilterProps) => {
-  const { filters, ...rest } = props;
+  const { filters, minimumFilters = 1, ...rest } = props;
   const auth = useAuth();
   const pathname = usePathname();
   const [settings, setSettings] = useSettingsStorage({
@@ -188,7 +189,7 @@ const Filter = (props: FilterProps) => {
     filters.map((filter) => ({
       id: filter.id,
       label: filter.label,
-      hide: filter.hide,
+      hide: filter.hide ?? false,
       resetFilters: resetFilters(filter),
     })),
   );
@@ -258,7 +259,9 @@ const Filter = (props: FilterProps) => {
                 xs={12}
                 md={node.columns || 12}
               >
-                {node.component}
+                {typeof node.component === 'function'
+                  ? node.component(filterOrder)
+                  : node.component}
               </Grid>
             ))
           : null}
@@ -274,10 +277,13 @@ const Filter = (props: FilterProps) => {
       >
         <OrderableDropDown
           icon={<FilterAlt />}
+          minimumItems={minimumFilters}
           list={filterOrder}
           setList={handleFilterOrderChange}
         />
-        {props.complementaryActions}
+        {typeof props.complementaryActions === 'function'
+          ? props.complementaryActions(filterOrder)
+          : props.complementaryActions}
       </Box>
     </Box>
   );

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -54,6 +54,9 @@ interface SortableItemProps {
   checked: boolean;
   label: string;
   labelId: string;
+  indeterminate?: boolean;
+  isHeader?: boolean;
+  handleToggle: (value: string) => void;
   disabled?: boolean;
 }
 
@@ -66,7 +69,7 @@ const SortableItem = (props: SortableItemProps) => {
     indeterminate,
     isHeader = false,
     handleToggle,
-    disabled = false
+    disabled = false,
   } = props;
 
   const { attributes, listeners, setNodeRef, transform, transition } =

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -135,7 +135,7 @@ const SortableItem = (props: SortableItemProps) => {
 const OrderableDropDown = ({
   list,
   setList,
-  minimumItems = 1,
+  minimumItems = 0,
   hasAllOption = false,
   icon = <SettingsSuggest />,
   text,

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -43,6 +43,7 @@ export interface ListItem {
 interface Props {
   list: ListItem[];
   icon?: ReactNode;
+  minimumItems?: number;
   setList: React.Dispatch<React.SetStateAction<ListItem[]>>;
   text?: string;
 }
@@ -53,10 +54,11 @@ interface SortableItemProps {
   label: string;
   handleToggle: (value: string) => () => void;
   labelId: string;
+  disabled?: boolean;
 }
 
 const SortableItem = (props: SortableItemProps) => {
-  const { id, checked, label, handleToggle, labelId } = props;
+  const { id, checked, label, handleToggle, labelId, disabled = false } = props;
 
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id });
@@ -80,6 +82,7 @@ const SortableItem = (props: SortableItemProps) => {
           <Checkbox
             edge="end"
             onChange={handleToggle(id)}
+            disabled={disabled}
             checked={checked.indexOf(id) !== -1}
             inputProps={{ 'aria-labelledby': labelId }}
           />
@@ -87,6 +90,7 @@ const SortableItem = (props: SortableItemProps) => {
         disablePadding
       >
         <ListItemButton
+          disabled={disabled}
           sx={{
             columnGap: (theme) => theme.spacing(2),
           }}
@@ -109,6 +113,7 @@ const SortableItem = (props: SortableItemProps) => {
 const OrderableDropDown = ({
   list,
   setList,
+  minimumItems = 1,
   icon = <SettingsSuggest />,
   text,
 }: Props) => {
@@ -216,6 +221,10 @@ const OrderableDropDown = ({
 
               return (
                 <SortableItem
+                  disabled={
+                    minimumItems === list.filter((item) => !item.hide).length &&
+                    !listItem.hide
+                  }
                   key={listItem.id}
                   id={listItem.id}
                   checked={checked}


### PR DESCRIPTION
### About

This PR adds:
- `complementaryActions` and `additionalGridItems` can now receive render functions and have access to the filters state.
- minimum items alllowed in the filters