### PR TITLE
feat: add first otp input version

### DIFF
--- a/packages/react-material-ui/__tests__/OtpInput.spec.tsx
+++ b/packages/react-material-ui/__tests__/OtpInput.spec.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import OtpInput from '../src/components/OtpInput';
+
+describe('components/MuiOtpInput', () => {
+  test('should not crash', () => {
+    render(<OtpInput />);
+  });
+
+  test('should display 4 inputs by default', () => {
+    render(<OtpInput />);
+    expect(screen.getAllByRole('textbox').length).toBe(4);
+  });
+
+  test('should display n inputs according to the length prop', () => {
+    render(<OtpInput length={5} />);
+    expect(screen.getAllByRole('textbox').length).toBe(5);
+  });
+
+  test('should split value into different inputs', () => {
+    render(<OtpInput value="abcd" />);
+
+    expect(screen.getByDisplayValue('a')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('b')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('c')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('d')).toBeInTheDocument();
+  });
+
+  test('should split value into different inputs or let empty value', () => {
+    render(<OtpInput value="ab" />);
+    expect(screen.getByDisplayValue('a')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('b')).toBeInTheDocument();
+    expect(screen.getAllByDisplayValue('')).toHaveLength(2);
+  });
+});

--- a/packages/react-material-ui/src/components/OtpInput/index.tsx
+++ b/packages/react-material-ui/src/components/OtpInput/index.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import type { BoxProps as MuiBoxProps } from '@mui/material/Box';
+import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
+
+type OmittedTextFieldProps = Omit<
+  MuiTextFieldProps,
+  'onChange' | 'select' | 'multiline' | 'defaultValue' | 'value' | 'autoFocus'
+>;
+
+type OmittedBoxProps = Omit<MuiBoxProps, 'onChange' | 'onBlur'>;
+
+export interface BaseOtpInputProps {
+  value?: string;
+  length?: number;
+  autoFocus?: boolean;
+  textFieldProps?:
+    | OmittedTextFieldProps
+    | ((index: number) => OmittedTextFieldProps);
+  onComplete?: (value: string) => void;
+  onChange?: (value: string) => void;
+  onBlur?: (value: string, isComplete: boolean) => void;
+}
+
+type OtpInputProps = OmittedBoxProps & BaseOtpInputProps;
+
+export const KEYBOARD_KEYS = {
+  LEFT: 'ArrowLeft',
+  RIGHT: 'ArrowRight',
+  BACKSPACE: 'Backspace',
+  HOME: 'Home',
+  END: 'End',
+} as const;
+
+type SplittedValue = {
+  character: string;
+  inputRef: React.RefObject<HTMLInputElement>;
+}[];
+
+const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
+  (
+    {
+      value = '',
+      length = 4,
+      autoFocus = false,
+      onChange,
+      textFieldProps,
+      onComplete,
+      className,
+      onBlur,
+      ...restBoxProps
+    }: OtpInputProps,
+    ref,
+  ) => {
+    const checkCompletion = (inputValue: string) =>
+      inputValue.slice(0, length).length === length;
+
+    const initializeInputs = (): SplittedValue =>
+      Array.from({ length }, (_, index) => ({
+        character: value[index] ?? '',
+        inputRef: React.createRef<HTMLInputElement>(),
+      }));
+
+    const inputData = initializeInputs();
+
+    const updateValue = (index: number, char: string) =>
+      value.slice(0, index) + char + value.slice(index + 1);
+
+    const focusInput = (index: number) => {
+      if (index < length) inputData[index]?.inputRef.current?.select();
+    };
+
+    const handleChange = (
+      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+      index: number,
+    ) => {
+      if (index === 0 && event.target.value.length > 1) {
+        const inputComplete = checkCompletion(event.target.value);
+        onChange?.(event.target.value);
+        if (inputComplete) onComplete?.(event.target.value);
+        focusInput(event.target.value.length - 1);
+        return;
+      }
+
+      const char = event.target.value[0] ?? '';
+      const newValue = updateValue(index, char);
+      onChange?.(newValue);
+
+      if (char && /[A-Za-z0-9]/.test(char)) {
+        focusInput(newValue.length - 1 < index ? newValue.length : index + 1);
+      } else if (newValue.length <= index) {
+        focusInput(index - 1);
+      }
+
+      if (checkCompletion(newValue)) onComplete?.(newValue);
+    };
+
+    const handleKeyDown = (
+      event: React.KeyboardEvent<HTMLDivElement>,
+      index: number,
+    ) => {
+      const inputElement = event.target as HTMLInputElement;
+      const caretAtStart =
+        inputElement.selectionStart === 0 && inputElement.selectionEnd === 0;
+
+      if (inputElement.value === event.key) {
+        event.preventDefault();
+        focusInput(index + 1);
+      } else if (event.key === KEYBOARD_KEYS.BACKSPACE) {
+        if (!inputElement.value) {
+          event.preventDefault();
+          focusInput(index - 1);
+        } else if (caretAtStart) {
+          event.preventDefault();
+          const newValue = updateValue(index, '');
+          onChange?.(newValue);
+          if (newValue.length <= index) focusInput(index - 1);
+        }
+      } else if (event.key === KEYBOARD_KEYS.LEFT) {
+        event.preventDefault();
+        focusInput(index - 1);
+      } else if (event.key === KEYBOARD_KEYS.RIGHT) {
+        event.preventDefault();
+        focusInput(index + 1);
+      } else if (event.key === KEYBOARD_KEYS.HOME) {
+        event.preventDefault();
+        focusInput(0);
+      } else if (event.key === KEYBOARD_KEYS.END) {
+        event.preventDefault();
+        focusInput(length - 1);
+      }
+    };
+
+    const handlePaste = (
+      event: React.ClipboardEvent<HTMLDivElement>,
+      index: number,
+    ) => {
+      const pastedData = event.clipboardData.getData('text/plain');
+      const newValue =
+        pastedData.length <= length - index
+          ? value.slice(0, index) +
+            pastedData +
+            value.slice(index + pastedData.length, length)
+          : value;
+      onChange?.(newValue);
+      if (checkCompletion(newValue)) {
+        onComplete?.(newValue);
+        focusInput(length - 1);
+      } else {
+        focusInput(newValue.length);
+      }
+    };
+
+    const handleBlurEvent = (
+      event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+      const isInputFocused = inputData.some(
+        ({ inputRef }) => inputRef.current === event.relatedTarget,
+      );
+      if (!isInputFocused) {
+        const isComplete = checkCompletion(value);
+        onBlur?.(value, isComplete);
+      }
+    };
+
+    return (
+      <Box
+        display="flex"
+        gap="20px"
+        alignItems="center"
+        ref={ref}
+        className={`otp-input-box ${className || ''}`}
+        {...restBoxProps}
+      >
+        {inputData.map(({ character, inputRef }, index) => {
+          const {
+            onPaste,
+            onFocus,
+            onKeyDown,
+            className,
+            onBlur: textFieldBlur,
+            ...restTextFieldProps
+          } = typeof textFieldProps === 'function'
+            ? textFieldProps(index) || {}
+            : textFieldProps || {};
+
+          return (
+            <TextField
+              key={`otp-input-${index}`}
+              autoFocus={autoFocus && index === 0}
+              autoComplete="one-time-code"
+              value={character}
+              inputRef={inputRef}
+              inputProps={{
+                sx: {
+                  textAlign: 'center',
+                },
+              }}
+              InputProps={{
+                sx: {
+                  caretColor: 'transparent',
+                  '.MuiInputBase-input::selection': {
+                    backgroundColor: 'transparent',
+                  },
+                },
+              }}
+              className={className}
+              onPaste={(event) => {
+                event.preventDefault();
+                handlePaste(event, index);
+                onPaste?.(event);
+              }}
+              onFocus={(event) => {
+                event.preventDefault();
+                event.target.select();
+                onFocus?.(event);
+              }}
+              onChange={(event) => handleChange(event, index)}
+              onKeyDown={(event) => {
+                handleKeyDown(event, index);
+                onKeyDown?.(event);
+              }}
+              onBlur={(event) => {
+                textFieldBlur?.(event);
+                handleBlurEvent(event);
+              }}
+              {...restTextFieldProps}
+            />
+          );
+        })}
+      </Box>
+    );
+  },
+);
+
+export default OtpInput;

--- a/packages/react-material-ui/src/index.ts
+++ b/packages/react-material-ui/src/index.ts
@@ -53,3 +53,5 @@ export { default as ComposedTable } from './components/ComposedTable';
 export { default as AuthModule } from './modules/auth';
 export { default as CrudModule } from './modules/crud';
 export { default as UsersModule } from './modules/users';
+
+export { default as OtpInput } from './components/OtpInput';


### PR DESCRIPTION
### About

This PR adds the first version of the OtpInput component. This PR doesn't add supporte for using OtpInput with RJSF.

### How to use

```
  const [otp, setOtp] = useState('');

   <OtpInput value={otp} onChange={setOtp} />
```

### Preview

https://github.com/conceptadev/rockets-react/assets/14095527/91220127-7597-468f-befe-341dd5a7a850