### PR TITLE
feat: auth and data providers enhancements

### DIFF
--- a/packages/react-auth-provider/src/index.tsx
+++ b/packages/react-auth-provider/src/index.tsx
@@ -35,14 +35,13 @@ const AuthProvider = ({
     setAccessToken(_accessToken);
   }, []);
 
-  const authLogin = (loginData: LoginParams) =>
-    post({
-      uri: loginData.loginPath || '/auth/signin',
-      body: {
-        username: loginData.username,
-        password: loginData.password,
-      },
+  const authLogin = (loginData: LoginParams) => {
+    const { loginPath, ...bodyData } = loginData;
+    return post({
+      uri: loginPath || '/auth/signin',
+      body: bodyData,
     });
+  };
 
   const { execute, isPending } = useQuery<AuthReponse>(authLogin, false, {
     onSuccess: (data) => {

--- a/packages/react-auth-provider/src/index.tsx
+++ b/packages/react-auth-provider/src/index.tsx
@@ -10,6 +10,7 @@ import React, {
 
 import {
   LoginParams,
+  DoLogin,
   AuthProviderProps,
   AuthProviderTypes,
   AuthReponse,
@@ -59,7 +60,7 @@ const AuthProvider = ({
     },
   });
 
-  const doLogin = async (loginData: LoginParams) => {
+  const doLogin: DoLogin = async (loginData) => {
     execute(loginData);
   };
 

--- a/packages/react-auth-provider/src/interfaces/index.ts
+++ b/packages/react-auth-provider/src/interfaces/index.ts
@@ -1,7 +1,8 @@
 export interface LoginParams {
-  username: string;
-  password: string;
   loginPath?: string;
+  username?: string;
+  password?: string;
+  [key: string]: string | number;
 }
 
 export type AuthProviderProps = {

--- a/packages/react-auth-provider/src/interfaces/index.ts
+++ b/packages/react-auth-provider/src/interfaces/index.ts
@@ -2,7 +2,7 @@ export interface LoginParams {
   loginPath?: string;
   username?: string;
   password?: string;
-  [key: string]: string | number;
+  [key: string]: string | number | boolean;
 }
 
 export type AuthProviderProps = {
@@ -10,10 +10,14 @@ export type AuthProviderProps = {
   onError?: (error?: Error) => void;
 };
 
+export type DoLogin = <TLoginParams>(
+  loginData: LoginParams | TLoginParams,
+) => void;
+
 export type AuthProviderTypes = {
   user: unknown;
   setUser: React.Dispatch<unknown>;
-  doLogin: (loginData: LoginParams) => void;
+  doLogin: DoLogin;
   doLogout: () => void;
   isPending: unknown;
   accessToken: string;

--- a/packages/react-data-provider/src/ClientProvider.tsx
+++ b/packages/react-data-provider/src/ClientProvider.tsx
@@ -21,7 +21,7 @@ export const useClient = () => useContext<ClientContextType>(ClientContext);
 
 type Props = {
   baseUrl?: string;
-  onRefreshTokenError: (error?: HttpError) => void;
+  onRefreshTokenError?: (error?: HttpError) => void;
   children: ReactNode;
 };
 

--- a/packages/react-data-provider/src/useDataProvider.ts
+++ b/packages/react-data-provider/src/useDataProvider.ts
@@ -55,7 +55,7 @@ const useDataProvider = () => {
       } catch (error) {
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
-        onRefreshTokenError(error);
+        onRefreshTokenError?.(error);
         return Promise.reject(error);
       }
     },


### PR DESCRIPTION
**Auth Provider**
- Change LoginParams interface to accept any keys with string or number
- Change authLogin function to accept the new LoginParams format

**Data Provider**
- Change useDataProvider and ClientProvider to accept onRefreshTokenError as optional


## Preview

![Screenshot 2024-05-29 093855](https://github.com/conceptadev/rockets-react/assets/32578927/bea32bb5-a4e3-4787-a84a-fbedeb229f69)
doLogin still works with username and password, which are suggested by the interface

![Screenshot 2024-05-29 093822](https://github.com/conceptadev/rockets-react/assets/32578927/fc1ea7ab-d965-42ae-b6a8-06a12f4f812d)
doLogin now works with any other keys as long as they use string or number

![Screenshot 2024-05-29 094516](https://github.com/conceptadev/rockets-react/assets/32578927/30ac0db2-afa6-40ef-aad8-a33e42b0c723)
ClientProvider's `onRefreshTokenError` prop is no longer mandatory