### PR TITLE
feat: add modal info for mobile table

### DIFF
--- a/packages/react-material-ui/src/components/AutocompleteField/AutocompleteField.tsx
+++ b/packages/react-material-ui/src/components/AutocompleteField/AutocompleteField.tsx
@@ -142,6 +142,11 @@ const AutocompleteField = ({
           </li>
         );
       }}
+      sx={{
+        '& .MuiInputLabel-root': {
+          pr: '16px',
+        },
+      }}
       {...rest}
     />
   );

--- a/packages/react-material-ui/src/components/Table/Table.tsx
+++ b/packages/react-material-ui/src/components/Table/Table.tsx
@@ -3,6 +3,7 @@
 import React, { PropsWithChildren } from 'react';
 import { TableProps as MuiTableProps } from '@mui/material';
 import { Table as MuiTable, TableProps as TableStylesProps } from './Styles';
+import { isMobile } from '../../utils/isMobile';
 
 export type TableProps = {
   variant?: TableStylesProps['variant'];
@@ -25,7 +26,7 @@ export const Table = ({
     {...rest}
     sx={[
       {
-        minWidth: 750,
+        minWidth: isMobile ? 'auto' : 750,
       },
       ...(Array.isArray(sx) ? sx : [sx]),
     ]}

--- a/packages/react-material-ui/src/components/Table/TableBody/TableBodyCells.tsx
+++ b/packages/react-material-ui/src/components/Table/TableBody/TableBodyCells.tsx
@@ -3,9 +3,11 @@
 import React, { ReactNode } from 'react';
 import Text from '../../Text';
 import { TableCell, TableCellProps, Tooltip } from '@mui/material';
+import get from 'lodash/get';
+
 import { CustomTableCell, RowProps } from '../types';
 import { useTableRoot } from '../hooks/useTableRoot';
-import get from 'lodash/get';
+import { isMobile } from '../../../utils/isMobile';
 
 const renderTextCell = (value: string | number | null) => (
   <Text fontSize={14} fontWeight={400} color="text.primary">
@@ -54,6 +56,7 @@ export const TableBodyCells = ({ row, ...rest }: TableBodyCellsProps) => {
     <>
       {headers.map((header) => {
         if (header.hide) return null;
+        if (isMobile && header.hideOnMobile) return null;
 
         return (
           <TableCell key={header.id} {...rest}>

--- a/packages/react-material-ui/src/components/Table/TableHeader/TableHeaderCells.tsx
+++ b/packages/react-material-ui/src/components/Table/TableHeader/TableHeaderCells.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, Fragment } from 'react';
 import { useTableRoot } from '../hooks/useTableRoot';
 import { TableHeaderCell } from './TableHeaderCell';
 import { HeaderProps } from '../types';
+import { isMobile } from '../../../utils/isMobile';
 
 type TableHeaderCellsProps = {
   renderCell?: (cell: HeaderProps) => ReactNode;
@@ -30,6 +31,7 @@ export const TableHeaderCells = ({ renderCell }: TableHeaderCellsProps) => {
       {!!renderCell &&
         headers.map((header) => {
           if (header.hide) return null;
+          if (isMobile && header.hideOnMobile) return null;
 
           return (
             <Fragment key={header.id}>

--- a/packages/react-material-ui/src/components/Table/types.ts
+++ b/packages/react-material-ui/src/components/Table/types.ts
@@ -22,6 +22,7 @@ export type HeaderProps = {
   sortable?: boolean;
   key?: number | string;
   hide?: boolean;
+  hideOnMobile?: boolean;
 };
 
 export type CustomTableCell = {

--- a/packages/react-material-ui/src/components/submodules/Table/MobileRowModal.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/MobileRowModal.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import React from 'react';
+import get from 'lodash/get';
+import { Tooltip, Box, Dialog, DialogContent, IconButton } from '@mui/material';
+import { Close as CloseIcon } from '@mui/icons-material';
+
+import Text from '../../Text';
+import { CustomTableCell, RowProps } from '../../Table/types';
+import { useTableRoot } from '../../Table/hooks/useTableRoot';
+
+interface Props {
+  currentRow: RowProps | null;
+  onClose: () => void;
+  titleSrc?: string;
+}
+
+const getCellData = (row: RowProps, dataOrigin: string) => {
+  const cell: CustomTableCell | string | number | undefined = get(
+    row,
+    dataOrigin,
+  );
+
+  if (!cell) return '';
+
+  if (
+    typeof cell === 'number' ||
+    typeof cell === 'string' ||
+    typeof cell === 'undefined'
+  ) {
+    return (
+      <Text fontSize={14} fontWeight={400} color="text.primary">
+        {cell ?? ''}
+      </Text>
+    );
+  }
+
+  if ('component' in cell) {
+    return cell.component;
+  }
+
+  if ('title' in cell) {
+    return (
+      <Tooltip title={cell.title}>
+        <span>{cell.value ?? ''}</span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Text fontSize={14} fontWeight={400} color="text.primary">
+      {cell.value ?? ''}
+    </Text>
+  );
+};
+
+const MobileRowModal = ({ currentRow, onClose, titleSrc }: Props) => {
+  const { headers } = useTableRoot();
+
+  return (
+    <Dialog open={!!currentRow} fullWidth onClose={onClose}>
+      <Box display="flex" justifyContent="space-between">
+        {titleSrc &&
+          currentRow?.[titleSrc] &&
+          typeof currentRow[titleSrc] === 'string' && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                px: 3,
+                width: '100%',
+                overflow: 'hidden',
+              }}
+            >
+              <Text
+                fontSize={14}
+                fontWeight={400}
+                color="text.primary"
+                sx={{
+                  width: '100%',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {currentRow[titleSrc] as string}
+              </Text>
+            </Box>
+          )}
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent sx={{ display: 'block' }}>
+        <Box>
+          {headers?.map((header) => {
+            if (header.hide || !header.label) return null;
+
+            return (
+              <Box
+                key={header.id}
+                display="flex"
+                sx={{ mb: 2, alignItems: 'center' }}
+              >
+                <Box
+                  sx={{
+                    display: 'block',
+                    alignItems: 'center',
+                    fontSize: 12,
+                    width: 70,
+                    minWidth: 70,
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    paddingRight: '3px',
+                    borderRight: '1px solid #ccc',
+
+                    p: {
+                      textOverflow: 'ellipsis',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      fontSize: 12,
+                    },
+                  }}
+                >
+                  {header.label}
+                </Box>
+                <Box
+                  sx={{
+                    display: 'block',
+                    alignItems: 'center',
+                    fontSize: 12,
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    paddingLeft: '6px',
+
+                    '& p': {
+                      textOverflow: 'ellipsis',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      fontSize: '12px !important',
+                    },
+                  }}
+                >
+                  {getCellData(currentRow, header.source || header.id)}
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MobileRowModal;

--- a/packages/react-material-ui/src/components/submodules/Table/README.md
+++ b/packages/react-material-ui/src/components/submodules/Table/README.md
@@ -18,12 +18,12 @@ Important to mention that `format` represents a custom format for the column dat
 ```js
 [
   {
-    id: "fullName", // required
-    label: "Full Name", // required
+    id: 'fullName', // required
+    label: 'Full Name', // required
     disablePadding: false,
     width: 100,
     numeric: false,
-    textAlign: "left" | "center" | "right",
+    textAlign: 'left' | 'center' | 'right',
     sortable: true,
     format: (value: string | number) => new Date(value).toString(),
   },
@@ -148,3 +148,111 @@ Can be passed via the `useTable` hook or independently.
 
 **type**: `React.Dispatch<React.SetStateAction<TableQueryStateProps>>`\
 **required**: `true`
+
+## Mobile Props
+
+### **allowModalPreview**
+
+Enables a modal preview for table rows when viewed on mobile devices.
+
+**type**: `boolean`\
+**required**: `false`
+
+### **mobileModalTitleSrc**
+
+Specifies the source for the modal's title when the modal preview is enabled on mobile devices.
+
+**type**: `string`\
+**required**: `false`
+
+### `hideOnMobile` (inside tableSchema)
+
+Allows you to hide specific columns when the table is viewed on a mobile device.
+
+**type**: `boolean`\
+**required**: `false`
+
+## Usage Guide for Mobile Row Preview
+
+This guide explains how to use the `allowModalPreview`, `mobileModalTitleSrc`, and `hideOnMobile` properties in your TableSubmodule component.
+
+### `allowModalPreview`
+
+Set `allowModalPreview` to `true` to allow a modal to be displayed when a table row is clicked on a mobile device.
+
+```jsx
+<TableSubmodule
+  allowModalPreview={true}
+  // other props
+/>
+```
+
+### `mobileModalTitleSrc`
+
+Provide the key of the data field you want to use as the title in the modal preview.
+
+```jsx
+<TableSubmodule
+  allowModalPreview={true}
+  mobileModalTitleSrc="name"
+  // other props
+/>
+```
+
+### `hideOnMobile`
+
+Set `hideOnMobile` to `true` in the column definition within the `tableSchema` to hide the column on mobile devices.
+
+```jsx
+const tableSchema = [
+  {
+    id: 'name',
+    label: 'Name',
+    hideOnMobile: false,
+  },
+  {
+    id: 'email',
+    label: 'Email',
+    hideOnMobile: true,
+  },
+  // other columns
+];
+
+<TableSubmodule
+  tableSchema={tableSchema}
+  // other props
+/>;
+```
+
+### Example
+
+Below is a complete example of using these properties in the `TableSubmodule` component.
+
+```jsx
+const tableSchema = [
+  {
+    id: 'name',
+    label: 'Name',
+    hideOnMobile: false,
+  },
+  {
+    id: 'email',
+    label: 'Email',
+    hideOnMobile: true,
+  },
+  // other columns
+];
+
+<TableSubmodule
+  allowModalPreview={true}
+  mobileModalTitleSrc="name"
+  tableSchema={tableSchema}
+  // other props
+/>;
+```
+
+In this example:
+
+- The modal preview is enabled on mobile devices.
+- The modal title will use the `name` field.
+- The `email` column will be hidden on mobile devices.

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -107,6 +107,7 @@ export interface TableSubmoduleProps {
   search?: Search;
   updateSearch?: UpdateSearch;
   paginationStyle?: PaginationStyle;
+  allowModalPreview?: boolean;
   mobileModalTitleSrc?: string;
 }
 
@@ -329,9 +330,10 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
                     hasCheckboxes={false}
                     hover={false}
                     sx={tableTheme.tableBodyRow}
-                    {...(isMobile && {
-                      onClick: () => setMobileCurrentRow(row),
-                    })}
+                    {...(isMobile &&
+                      props.allowModalPreview && {
+                        onClick: () => setMobileCurrentRow(row),
+                      })}
                   >
                     <Table.BodyCell row={row} sx={tableTheme.tableBodyCell} />
                   </Table.BodyRow>
@@ -372,7 +374,7 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
             })}
           />
         )}
-        {isMobile && (
+        {props.allowModalPreview && isMobile && (
           <MobileRowModal
             currentRow={mobileCurrentRow}
             onClose={closeModal}

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import type {
   CustomTableCell,
@@ -38,6 +38,8 @@ import FilterSubmodule from '../../../components/submodules/Filter';
 import { Search } from '../../../components/Table/types';
 import { UpdateSearch } from '../../../components/Table/useTable';
 import { useCrudRoot } from '../../../modules/crud/useCrudRoot';
+import { isMobile } from '../../../utils/isMobile';
+import MobileRowModal from './MobileRowModal';
 
 type Action = 'creation' | 'edit' | 'details' | null;
 
@@ -105,12 +107,15 @@ export interface TableSubmoduleProps {
   search?: Search;
   updateSearch?: UpdateSearch;
   paginationStyle?: PaginationStyle;
+  mobileModalTitleSrc?: string;
 }
 
 const TableSubmodule = (props: TableSubmoduleProps) => {
   const theme = useTheme();
   const { filters } = useCrudRoot();
-
+  const [mobileCurrentRow, setMobileCurrentRow] = useState<RowProps | null>(
+    null,
+  );
   const { del } = useDataProvider();
 
   const { execute: deleteItem } = useQuery(
@@ -184,10 +189,11 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
         ...newData,
         actions: {
           component: (
-            <Box>
+            <Box display="flex">
               {!props.hideEditButton && (
                 <IconButton
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     if (props.onAction) {
                       props.onAction({ action: 'edit', row: rowData });
                     }
@@ -198,14 +204,20 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
               )}
 
               {!props.hideDeleteButton && (
-                <IconButton onClick={() => deleteItem(rowData.id)}>
+                <IconButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    deleteItem(rowData.id);
+                  }}
+                >
                   <DeleteIcon />
                 </IconButton>
               )}
 
               {!props.hideDetailsButton && (
                 <IconButton
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     if (props.onAction) {
                       props.onAction({ action: 'details', row: rowData });
                     }
@@ -220,6 +232,10 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
       };
     });
   }, [props, tableHeaders, deleteItem]);
+
+  const closeModal = () => {
+    setMobileCurrentRow(null);
+  };
 
   return (
     <Box>
@@ -313,6 +329,9 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
                     hasCheckboxes={false}
                     hover={false}
                     sx={tableTheme.tableBodyRow}
+                    {...(isMobile && {
+                      onClick: () => setMobileCurrentRow(row),
+                    })}
                   >
                     <Table.BodyCell row={row} sx={tableTheme.tableBodyCell} />
                   </Table.BodyRow>
@@ -326,7 +345,39 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
             <Table.PaginationNumbers />
           </Box>
         ) : (
-          <Table.Pagination variant="outlined" />
+          <Table.Pagination
+            variant="outlined"
+            {...(isMobile && {
+              labelRowsPerPage: 'per page:',
+              sx: {
+                display: 'flex',
+                justifyContent: 'center',
+                '& .MuiTablePagination-selectLabel': {
+                  paddingLeft: '10px',
+                },
+                '& .MuiToolbar-root': {
+                  padding: 0,
+                },
+                '& .MuiTablePagination-spacer': {
+                  display: 'none',
+                },
+                '& .MuiTablePagination-input': {
+                  marginRight: 0,
+                  marginLeft: 0,
+                },
+                '& .MuiTablePagination-actions': {
+                  marginLeft: '0 !important',
+                },
+              },
+            })}
+          />
+        )}
+        {isMobile && (
+          <MobileRowModal
+            currentRow={mobileCurrentRow}
+            onClose={closeModal}
+            titleSrc={props.mobileModalTitleSrc}
+          />
         )}
       </Table.Root>
     </Box>

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -34,6 +34,7 @@ interface TableProps {
   paginationStyle?: PaginationStyle;
   onDeleteSuccess?: (data: unknown) => void;
   onDeleteError?: (error: unknown) => void;
+  mobileModalTitleSrc?: string;
 }
 
 interface FormProps {

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -35,6 +35,7 @@ interface TableProps {
   onDeleteSuccess?: (data: unknown) => void;
   onDeleteError?: (error: unknown) => void;
   mobileModalTitleSrc?: string;
+  allowModalPreview?: boolean;
 }
 
 interface FormProps {

--- a/packages/react-material-ui/src/utils/isMobile.ts
+++ b/packages/react-material-ui/src/utils/isMobile.ts
@@ -1,0 +1,6 @@
+const isMobile =
+  /Android|BlackBerryi|iPhone|iPad|iPodi|Opera Minii|IEMobilei|WPDesktop/i.test(
+    navigator.userAgent,
+  );
+
+export { isMobile };


### PR DESCRIPTION
Add info modal for tables in mobile devices

How to use it?
Add "hideOnMobile: true" to the headers you want to hide in the regular table for mobile

You can pass the title source for the modal title.
```
<CrudModule
  tableProps={{
    mobileModalTitleSrc: 'fullName',
    tableSchema: [
          {
            id: 'id',
            label: 'ID',
            hideOnMobile: true,
          }
    ]
    ...
  }}
/>
```

![Screenshot 2024-06-26 171607](https://github.com/conceptadev/rockets-react/assets/32578927/512a23a7-6218-4cdc-9218-fb37098bbd23)
![Screenshot 2024-06-26 171614](https://github.com/conceptadev/rockets-react/assets/32578927/93cd9634-06d7-4176-b511-c9384b59d5ca)
