### PR TITLE
Integrate Filter settings with Cache Module endpoints

### DIFF
--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -38,7 +38,7 @@ const ComposedTable = (props: ComposedTableProps) => {
 
   const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
 
-  const { setSettings, updateCache } = useSettingsStorage({
+  const { setSettings, updateSettingsCache } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'table',
     assignee: {
@@ -66,7 +66,7 @@ const ComposedTable = (props: ComposedTableProps) => {
   const handleHeadersOrderChange = (list: ListItem[]) => {
     setOrderableHeaders(list);
     setSettings(list);
-    updateCache();
+    updateSettingsCache();
   };
 
   return (

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -48,6 +48,7 @@ const ComposedTable = (props: ComposedTableProps) => {
       id: header.id,
       hide: Boolean(header.hide),
     })),
+    cacheApiUri: props.settingsCacheUri,
     setListCallback: (callbackData) =>
       setOrderableHeaders(
         callbackData.map((item: ListItem) => {

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -36,7 +36,7 @@ const ComposedTable = (props: ComposedTableProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const { settings, setSettings } = useSettingsStorage({
+  const [settings, setSettings] = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'table',
     assignee: {

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -38,7 +38,7 @@ const ComposedTable = (props: ComposedTableProps) => {
 
   const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
 
-  const [settings, setSettings] = useSettingsStorage({
+  const { setSettings, updateCache } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'table',
     assignee: {
@@ -66,6 +66,7 @@ const ComposedTable = (props: ComposedTableProps) => {
   const handleHeadersOrderChange = (list: ListItem[]) => {
     setOrderableHeaders(list);
     setSettings(list);
+    updateCache();
   };
 
   return (

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -36,7 +36,7 @@ const ComposedTable = (props: ComposedTableProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const { cachedSettings, changeSettings } = useSettingsStorage({
+  const { settings, setSettings } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'table',
     assignee: {
@@ -52,13 +52,13 @@ const ComposedTable = (props: ComposedTableProps) => {
 
   const handleHeadersOrderChange = (list: ListItem[]) => {
     setOrderableHeaders(list);
-    changeSettings(list);
+    setSettings(list);
   };
 
   useEffect(() => {
-    if (cachedSettings.length) {
+    if (settings.length) {
       setOrderableHeaders(
-        cachedSettings.map((item: ListItem) => {
+        settings.map((item: ListItem) => {
           const headerItem = props.headers.find(
             (header) => header.id === item.id,
           );

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -36,6 +36,8 @@ const ComposedTable = (props: ComposedTableProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
+  const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
+
   const [settings, setSettings] = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'table',
@@ -47,8 +49,6 @@ const ComposedTable = (props: ComposedTableProps) => {
       hide: Boolean(header.hide),
     })),
   });
-
-  const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
 
   const handleHeadersOrderChange = (list: ListItem[]) => {
     setOrderableHeaders(list);

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -38,7 +38,7 @@ const ComposedTable = (props: ComposedTableProps) => {
 
   const [orderableHeaders, setOrderableHeaders] = useState(props.headers);
 
-  const { setSettings, updateSettingsCache } = useSettingsStorage({
+  const { setSettings } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'table',
     assignee: {
@@ -66,7 +66,6 @@ const ComposedTable = (props: ComposedTableProps) => {
   const handleHeadersOrderChange = (list: ListItem[]) => {
     setOrderableHeaders(list);
     setSettings(list);
-    updateSettingsCache();
   };
 
   return (

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -36,11 +36,13 @@ const ComposedTable = (props: ComposedTableProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const [settings, setSettings] = useSettingsStorage({
-    key: 'tableSettings',
-    user: (auth?.user as { id: string })?.id ?? '',
-    settingsId: props.settingsId || pathname,
-    list: props.headers.map((header) => ({
+  const { cachedSettings, changeSettings } = useSettingsStorage({
+    key: props.settingsId || pathname,
+    type: 'table',
+    assignee: {
+      id: (auth?.user as { id: string })?.id ?? '',
+    },
+    data: props.headers.map((header) => ({
       id: header.id,
       hide: Boolean(header.hide),
     })),
@@ -50,13 +52,13 @@ const ComposedTable = (props: ComposedTableProps) => {
 
   const handleHeadersOrderChange = (list: ListItem[]) => {
     setOrderableHeaders(list);
-    setSettings(list);
+    changeSettings(list);
   };
 
   useEffect(() => {
-    if (settings.length) {
+    if (cachedSettings.length) {
       setOrderableHeaders(
-        settings.map((item: ListItem) => {
+        cachedSettings.map((item: ListItem) => {
           const headerItem = props.headers.find(
             (header) => header.id === item.id,
           );

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import type { TableRootProps } from '../Table/TableRoot';
 import type { FilterProps } from '../Filter/Filter';
@@ -48,17 +48,9 @@ const ComposedTable = (props: ComposedTableProps) => {
       id: header.id,
       hide: Boolean(header.hide),
     })),
-  });
-
-  const handleHeadersOrderChange = (list: ListItem[]) => {
-    setOrderableHeaders(list);
-    setSettings(list);
-  };
-
-  useEffect(() => {
-    if (settings.length) {
+    setListCallback: (callbackData) =>
       setOrderableHeaders(
-        settings.map((item: ListItem) => {
+        callbackData.map((item: ListItem) => {
           const headerItem = props.headers.find(
             (header) => header.id === item.id,
           );
@@ -68,9 +60,13 @@ const ComposedTable = (props: ComposedTableProps) => {
             ...headerItem,
           };
         }),
-      );
-    }
-  }, []);
+      ),
+  });
+
+  const handleHeadersOrderChange = (list: ListItem[]) => {
+    setOrderableHeaders(list);
+    setSettings(list);
+  };
 
   return (
     <Box>

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -227,7 +227,7 @@ export const Filter = (props: FilterProps) => {
     })),
   );
 
-  const { setSettings, updateSettingsCache } = useSettingsStorage({
+  const { setSettings } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'filter',
     assignee: {
@@ -254,7 +254,6 @@ export const Filter = (props: FilterProps) => {
   const handleFilterOrderChange = (list: ListItem[]) => {
     setFilterOrder(list);
     setSettings(list);
-    updateSettingsCache();
   };
 
   useEffect(() => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -201,6 +201,7 @@ export type FilterProps = {
   complementaryActions?: ReactNode | ((filters: ListItem[]) => ReactNode);
   /** Settings identifier */
   settingsId?: string;
+  settingsCacheUri?: string;
 } & GridProps;
 
 export const Filter = (props: FilterProps) => {
@@ -237,6 +238,7 @@ export const Filter = (props: FilterProps) => {
       id: header.id,
       hide: Boolean(header.hide),
     })),
+    cacheApiUri: props.settingsCacheUri,
     setListCallback: (callbackData) =>
       setFilterOrder(
         callbackData.map((item: ListItem) => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -237,6 +237,18 @@ export const Filter = (props: FilterProps) => {
       id: header.id,
       hide: Boolean(header.hide),
     })),
+    setListCallback: (callbackData) =>
+      setFilterOrder(
+        callbackData.map((item: ListItem) => {
+          const filterItem = filters.find((filter) => filter.id === item.id);
+
+          return {
+            ...item,
+            ...filterItem,
+            resetFilters: resetFilters(filterItem),
+          };
+        }),
+      ),
   });
 
   console.log('SETTINGS: ', settings);

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -205,16 +205,15 @@ export type FilterProps = {
 
 export const Filter = (props: FilterProps) => {
   const { filters, minimumFilters = 0, hasAllOption, ...rest } = props;
+
   const auth = useAuth();
   const pathname = usePathname();
 
   const [settings, setSettings] = useSettingsStorage({
-    key: props.settingsId || pathname,
-    type: 'filter',
-    assignee: {
-      id: (auth?.user as { id: string })?.id ?? '',
-    },
-    data: filters.map((header) => ({
+    key: 'filterSettings',
+    user: (auth?.user as { id: string })?.id ?? '',
+    settingsId: props.settingsId || pathname,
+    list: filters.map((header) => ({
       id: header.id,
       hide: Boolean(header.hide),
     })),

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -208,11 +208,13 @@ export const Filter = (props: FilterProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const [settings, setSettings] = useSettingsStorage({
-    key: 'filterSettings',
-    user: (auth?.user as { id: string })?.id ?? '',
-    settingsId: props.settingsId || pathname,
-    list: filters.map((header) => ({
+  const { cachedSettings, changeSettings } = useSettingsStorage({
+    key: props.settingsId || pathname,
+    type: 'filter',
+    assignee: {
+      id: (auth?.user as { id: string })?.id ?? '',
+    },
+    data: filters.map((header) => ({
       id: header.id,
       hide: Boolean(header.hide),
     })),
@@ -222,7 +224,6 @@ export const Filter = (props: FilterProps) => {
     if (item && item?.onDebouncedSearchChange) {
       item.onDebouncedSearchChange(null);
     }
-
     if (item && item?.onChange) {
       item.onChange(null);
     }
@@ -239,15 +240,15 @@ export const Filter = (props: FilterProps) => {
 
   const handleFilterOrderChange = (list: ListItem[]) => {
     setFilterOrder(list);
-    setSettings(list);
+    changeSettings(list);
   };
 
   useEffect(() => {
-    if (settings.length) {
+    if (cachedSettings.length) {
       const originalFilters = [...filters];
       const newFiltersOrder = [];
 
-      settings.forEach((item: ListItem) => {
+      cachedSettings.forEach((item: ListItem) => {
         const filterItemIndex = originalFilters.findIndex(
           (filter) => filter?.id === item.id,
         );

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -209,16 +209,6 @@ export const Filter = (props: FilterProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const [settings, setSettings] = useSettingsStorage({
-    key: 'filterSettings',
-    user: (auth?.user as { id: string })?.id ?? '',
-    settingsId: props.settingsId || pathname,
-    list: filters.map((header) => ({
-      id: header.id,
-      hide: Boolean(header.hide),
-    })),
-  });
-
   const resetFilters = (item) => () => {
     if (item && item?.onDebouncedSearchChange) {
       item.onDebouncedSearchChange(null);
@@ -236,6 +226,20 @@ export const Filter = (props: FilterProps) => {
       resetFilters: resetFilters(filter),
     })),
   );
+
+  const [settings, setSettings] = useSettingsStorage({
+    key: props.settingsId || pathname,
+    type: 'filter',
+    assignee: {
+      id: (auth?.user as { id: string })?.id ?? '',
+    },
+    data: filters.map((header) => ({
+      id: header.id,
+      hide: Boolean(header.hide),
+    })),
+  });
+
+  console.log('SETTINGS: ', settings);
 
   const handleFilterOrderChange = (list: ListItem[]) => {
     setFilterOrder(list);

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -227,7 +227,7 @@ export const Filter = (props: FilterProps) => {
     })),
   );
 
-  const { setSettings, updateCache } = useSettingsStorage({
+  const { setSettings, updateSettingsCache } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'filter',
     assignee: {
@@ -252,10 +252,9 @@ export const Filter = (props: FilterProps) => {
   });
 
   const handleFilterOrderChange = (list: ListItem[]) => {
-    console.log('list: ', list);
     setFilterOrder(list);
     setSettings(list);
-    updateCache();
+    updateSettingsCache();
   };
 
   useEffect(() => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -227,7 +227,7 @@ export const Filter = (props: FilterProps) => {
     })),
   );
 
-  const { setSettings } = useSettingsStorage({
+  const { setSettings, updateCache } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'filter',
     assignee: {
@@ -255,6 +255,7 @@ export const Filter = (props: FilterProps) => {
     console.log('list: ', list);
     setFilterOrder(list);
     setSettings(list);
+    updateCache();
   };
 
   useEffect(() => {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -208,7 +208,7 @@ export const Filter = (props: FilterProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const { settings, setSettings } = useSettingsStorage({
+  const [settings, setSettings] = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'filter',
     assignee: {

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -208,7 +208,7 @@ export const Filter = (props: FilterProps) => {
   const auth = useAuth();
   const pathname = usePathname();
 
-  const { cachedSettings, changeSettings } = useSettingsStorage({
+  const { settings, setSettings } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'filter',
     assignee: {
@@ -240,15 +240,15 @@ export const Filter = (props: FilterProps) => {
 
   const handleFilterOrderChange = (list: ListItem[]) => {
     setFilterOrder(list);
-    changeSettings(list);
+    setSettings(list);
   };
 
   useEffect(() => {
-    if (cachedSettings.length) {
+    if (settings.length) {
       const originalFilters = [...filters];
       const newFiltersOrder = [];
 
-      cachedSettings.forEach((item: ListItem) => {
+      settings.forEach((item: ListItem) => {
         const filterItemIndex = originalFilters.findIndex(
           (filter) => filter?.id === item.id,
         );

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -227,7 +227,7 @@ export const Filter = (props: FilterProps) => {
     })),
   );
 
-  const [settings, setSettings] = useSettingsStorage({
+  const { setSettings } = useSettingsStorage({
     key: props.settingsId || pathname,
     type: 'filter',
     assignee: {
@@ -251,9 +251,8 @@ export const Filter = (props: FilterProps) => {
       ),
   });
 
-  console.log('SETTINGS: ', settings);
-
   const handleFilterOrderChange = (list: ListItem[]) => {
+    console.log('list: ', list);
     setFilterOrder(list);
     setSettings(list);
   };

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { Box, Grid, GridProps } from '@mui/material';
 import { FilterAlt } from '@mui/icons-material';
 import { useAuth } from '@concepta/react-auth-provider';
@@ -239,27 +239,7 @@ export const Filter = (props: FilterProps) => {
       hide: Boolean(header.hide),
     })),
     cacheApiUri: props.settingsCacheUri,
-    setListCallback: (callbackData) =>
-      setFilterOrder(
-        callbackData.map((item: ListItem) => {
-          const filterItem = filters.find((filter) => filter.id === item.id);
-
-          return {
-            ...item,
-            ...filterItem,
-            resetFilters: resetFilters(filterItem),
-          };
-        }),
-      ),
-  });
-
-  const handleFilterOrderChange = (list: ListItem[]) => {
-    setFilterOrder(list);
-    setSettings(list);
-  };
-
-  useEffect(() => {
-    if (settings.length) {
+    setListCallback: (settings) => {
       const originalFilters = [...filters];
       const newFiltersOrder = [];
 
@@ -268,6 +248,7 @@ export const Filter = (props: FilterProps) => {
           (filter) => filter?.id === item.id,
         );
         const filterItem = originalFilters[filterItemIndex];
+
         if (filterItem) {
           newFiltersOrder.push({
             ...item,
@@ -290,8 +271,13 @@ export const Filter = (props: FilterProps) => {
       });
 
       setFilterOrder(newFiltersOrder);
-    }
-  }, []);
+    },
+  });
+
+  const handleFilterOrderChange = (list: ListItem[]) => {
+    setFilterOrder(list);
+    setSettings(list);
+  };
 
   return (
     <Box

--- a/packages/react-material-ui/src/components/submodules/Filter/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Filter/index.tsx
@@ -39,7 +39,12 @@ export type FilterDetails = {
 
 export type FilterCallback = (filter: FilterValues) => void;
 
-const FilterSubmodule = () => {
+type Props = {
+  settingsId?: string;
+  settingsCacheUri?: string;
+};
+
+const FilterSubmodule = (props: Props) => {
   const {
     filters,
     updateSearch,
@@ -186,7 +191,7 @@ const FilterSubmodule = () => {
 
   if (filters.length === 0) return null;
 
-  return <Filter filters={filterObjs} />;
+  return <Filter {...props} filters={filterObjs} />;
 };
 
 export default FilterSubmodule;

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -109,6 +109,8 @@ export interface TableSubmoduleProps {
   paginationStyle?: PaginationStyle;
   allowModalPreview?: boolean;
   mobileModalTitleSrc?: string;
+  filterSettingsId?: string;
+  filterSettingsCacheUri?: string;
 }
 
 const TableSubmodule = (props: TableSubmoduleProps) => {
@@ -259,7 +261,12 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
             my: 4,
           }}
         >
-          {filters && <FilterSubmodule />}
+          {filters && (
+            <FilterSubmodule
+              settingsId={props.filterSettingsId}
+              settingsCacheUri={props.filterSettingsCacheUri}
+            />
+          )}
           <Box
             sx={{
               display: 'flex',

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -36,6 +36,10 @@ type CacheState = {
   data: ListItem[];
 } & CommonCacheInfo;
 
+type Props = {
+  callback?: () => void;
+} & Settings;
+
 const initialSettingsState = {
   id: '',
   dateCreated: '',
@@ -89,7 +93,7 @@ const updateStorageSettings = (
 };
 
 export const useSettingsStorage = (
-  props: Settings,
+  props: Props,
 ): [CacheState['data'], (list: ListItem[]) => void] => {
   const [settings, setSettings] = useState<CacheState>(initialSettingsState);
 
@@ -119,7 +123,7 @@ export const useSettingsStorage = (
     false,
   );
 
-  const { data: cachedData, isPending: isLoadingCachedData } = useQuery(
+  const { data: cachedData } = useQuery(
     () => get({ uri: '/cache/user' }),
     true,
     {
@@ -155,7 +159,7 @@ export const useSettingsStorage = (
   }, []);
 
   useEffect(() => {
-    if (!isLoadingCachedData && cachedData?.length && !settings?.data?.length) {
+    if (cachedData?.length) {
       const cachedSettings = getSettingsFromCacheList({
         ...settings,
         cacheList: cachedData,
@@ -163,9 +167,17 @@ export const useSettingsStorage = (
 
       console.log('cached settings: ', cachedSettings);
 
-      setSettings(cachedSettings);
+      if (cachedSettings) {
+        setSettings(cachedSettings);
+      }
     }
-  }, [isLoadingCachedData, cachedData, settings.data]);
+  }, [cachedData]);
+
+  useEffect(() => {
+    if (props.callback) {
+      props.callback();
+    }
+  }, [settings]);
 
   console.log('SETTINGS: ', settings);
 

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 
 type Assignee = {
   id: string;
@@ -17,136 +16,71 @@ type Settings = {
   data: ListItem[];
 };
 
-type CommonCacheInfo = {
-  id: string;
-  dateCreated: string;
-  dateUpdated: string;
-  dateDeleted?: string;
-  version: number;
-  key: string;
-  type: string;
-  assignee: Assignee;
-};
+// type CommonCacheInfo = {
+//   id: string;
+//   dateCreated: string;
+//   dateUpdated: string;
+//   dateDeleted?: string;
+//   version: number;
+//   key: string;
+//   type: string;
+//   assignee: Assignee;
+// };
 
-type CacheResponse = {
-  data: string;
-} & CommonCacheInfo;
+// type CacheResponse = {
+//   data: string;
+// } & CommonCacheInfo;
 
-type CacheState = {
-  data: ListItem[];
-} & CommonCacheInfo;
+// type CacheState = {
+//   data: ListItem[];
+// } & CommonCacheInfo;
 
-const getPageSettings = ({
-  key,
-  assignee,
-  type,
-  data,
-  cacheList,
-}: Settings & { cacheList: CacheResponse[] }) => {
-  console.log('cache list: ', cacheList);
+export const getPageSettings = ({ key, type, assignee, data }: Settings) => {
+  const storageItem = JSON.parse(localStorage.getItem(type));
 
-  const settingsItem = cacheList.find(
-    (item) =>
+  if (!storageItem) {
+    return data;
+  }
+
+  const settingsItem = storageItem.find(
+    (item: Settings) =>
       item.key === key &&
       item.type === type &&
       item.assignee.id === assignee.id,
   );
 
-  console.log('settings item: ', settingsItem);
-
-  return {
-    ...settingsItem,
-    data: settingsItem ? JSON.parse(settingsItem.data) : data,
-  };
+  return settingsItem?.data || data;
 };
 
-const handlePageSettingsUpdate = (data: CacheResponse) => {
-  localStorage.setItem(data.type, JSON.stringify(data));
-};
-
-export const useSettingsStorage = ({ key, assignee, type, data }: Settings) => {
-  const { get, post, patch } = useDataProvider();
-
-  const { execute: createCache } = useQuery(
-    (cache: Record<string, unknown>) =>
-      post({
-        uri: `/cache/user`,
-        body: {
-          key,
-          type,
-          assignee,
-          data: cache,
-        },
-      }),
-    false,
-    {
-      onSuccess: (data: CacheResponse) => handlePageSettingsUpdate(data),
-    },
-  );
-
-  const { execute: updateCache } = useQuery(
-    (cache: string) =>
-      patch({
-        uri: `/cache/user/${settingsState.id}`,
-        body: {
-          key,
-          type,
-          assignee,
-          data: cache,
-        },
-      }),
-    false,
-    {
-      onSuccess: (data: CacheResponse) => handlePageSettingsUpdate(data),
-    },
-  );
-
-  const { data: cachedData } = useQuery(
-    () => get({ uri: '/cache/user' }),
-    true,
-    {
-      onSuccess: (fetchedData: CacheResponse[]) => {
-        if (!fetchedData.length) {
-          createCache(JSON.stringify(data));
-        }
-      },
-    },
-  );
-
-  const [settingsState, setSettingsState] = useState<CacheState>({
-    id: '',
-    dateCreated: '',
-    dateUpdated: '',
-    dateDeleted: '',
-    version: 1,
-    key: key,
+export const handlePageSettingsUpdate = ({
+  key,
+  type,
+  assignee,
+  data,
+}: Settings) => {
+  const newSettings = {
+    key,
+    type,
+    assignee,
     data,
-    type: type,
-    assignee: assignee,
+  };
+
+  localStorage.setItem(type, JSON.stringify(newSettings));
+};
+
+export const useSettingsStorage = ({ key, type, assignee, data }: Settings) => {
+  const [settings, setSettings] = useState(() => {
+    return getPageSettings({ key, type, assignee, data });
   });
 
-  const setSettings = (list: ListItem[]) => {
-    setSettingsState({
-      ...settingsState,
-      data: list,
-    });
-
-    updateCache(JSON.stringify(list));
-  };
-
   useEffect(() => {
-    setSettingsState(
-      getPageSettings({
-        key,
-        type,
-        assignee,
-        data,
-        cacheList: cachedData || [],
-      }),
-    );
-  }, [cachedData]);
+    handlePageSettingsUpdate({
+      key,
+      type,
+      assignee,
+      data: settings,
+    });
+  }, [settings]);
 
-  console.log('SETTINGS: ', settingsState);
-
-  return { settings: settingsState.data, setSettings };
+  return [settings, setSettings];
 };

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -35,21 +35,14 @@ type Settings = {
 //   data: ListItem[];
 // } & CommonCacheInfo;
 
-export const getPageSettings = ({ key, type, assignee, data }: Settings) => {
+export const getPageSettings = ({ type, data }: Settings) => {
   const storageItem = JSON.parse(localStorage.getItem(type));
 
   if (!storageItem) {
     return data;
   }
 
-  const settingsItem = storageItem.find(
-    (item: Settings) =>
-      item.key === key &&
-      item.type === type &&
-      item.assignee.id === assignee.id,
-  );
-
-  return settingsItem?.data || data;
+  return storageItem.data;
 };
 
 export const handlePageSettingsUpdate = ({

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -1,3 +1,5 @@
+import type { Dispatch, SetStateAction } from 'react';
+
 import { useState, useEffect } from 'react';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 
@@ -37,7 +39,7 @@ type CacheState = {
 } & CommonCacheInfo;
 
 type Props = {
-  callback?: () => void;
+  setListCallback?: (list?: CacheState['data']) => void;
 } & Settings;
 
 const baseUri = '/cache/user';
@@ -83,7 +85,7 @@ export const handlePageSettingsUpdate = ({
   };
 
   if (!storageItem) {
-    localStorage.setItem(key, JSON.stringify([newSettings]));
+    localStorage.setItem(type, JSON.stringify([newSettings]));
     return;
   }
 
@@ -97,11 +99,17 @@ export const handlePageSettingsUpdate = ({
     storageItem.push(newSettings);
   }
 
-  localStorage.setItem(key, JSON.stringify(storageItem));
+  localStorage.setItem(type, JSON.stringify(storageItem));
 };
 
-export const useSettingsStorage = ({ key, type, assignee, data }: Props) => {
-  const [settings, setSettings] = useState(() => {
+export const useSettingsStorage = ({
+  key,
+  type,
+  assignee,
+  data,
+  setListCallback,
+}: Props): [CacheState['data'], Dispatch<SetStateAction<ListItem[]>>] => {
+  const [settings, setSettings] = useState<CacheState['data']>(() => {
     return getPageSettings({ key, type, assignee, data });
   });
 
@@ -113,6 +121,12 @@ export const useSettingsStorage = ({ key, type, assignee, data }: Props) => {
       data: settings,
     });
   }, [key, settings]);
+
+  useEffect(() => {
+    if (settings.length) {
+      setListCallback(settings);
+    }
+  }, []);
 
   return [settings, setSettings];
 };

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -1,7 +1,6 @@
-import type { Dispatch, SetStateAction } from 'react';
-
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
+import debounce from 'lodash/debounce';
 
 type Assignee = {
   id: string;
@@ -61,7 +60,7 @@ const parseDataStringToSettings = (data: string) => {
 };
 
 const parseSettingsToDataString = (data: string) => {
-  return data.replace(/\"/g, "'");
+  return data.replace(/"/g, "'");
 };
 
 const getSettingsFromStorage = ({ key, type, assignee, data }: Settings) => {
@@ -227,5 +226,10 @@ export const useSettingsStorage = ({
     }
   }, [settingsCache]);
 
-  return { settings, setSettings, updateCache };
+  const updateSettingsCache = useMemo(
+    () => debounce(updateCache, 2000),
+    [updateCache],
+  );
+
+  return { settings, setSettings, updateSettingsCache };
 };

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -71,21 +71,21 @@ const getSettingsFromCacheList = ({
     return null;
   }
 
+  const regex = /'/g;
+  const char = '"';
+  const data = JSON.parse(settingsItem.data.replace(regex, char));
+
   return {
     ...settingsItem,
-    data: JSON.parse(settingsItem.data),
+    data,
   };
 };
 
-const updateStorageSettings = ({ key, type, assignee, data }: Settings) => {
-  const newSettings = {
-    key,
-    type,
-    assignee,
-    data,
-  };
-
-  localStorage.setItem(type, JSON.stringify(newSettings));
+const updateStorageSettings = (
+  type: CommonCacheInfo['type'],
+  cacheState: CacheState,
+) => {
+  localStorage.setItem(type, JSON.stringify(cacheState));
 };
 
 export const useSettingsStorage = (
@@ -141,6 +141,11 @@ export const useSettingsStorage = (
       ...settings,
       data,
     });
+
+    updateStorageSettings(props.type, {
+      ...settings,
+      data,
+    });
   };
 
   useEffect(() => {
@@ -150,19 +155,19 @@ export const useSettingsStorage = (
   }, []);
 
   useEffect(() => {
-    if (!isLoadingCachedData && cachedData.length && !settings.data.length) {
+    if (!isLoadingCachedData && cachedData?.length && !settings?.data?.length) {
       const cachedSettings = getSettingsFromCacheList({
         ...settings,
         cacheList: cachedData,
       });
 
       console.log('cached settings: ', cachedSettings);
+
+      setSettings(cachedSettings);
     }
   }, [isLoadingCachedData, cachedData, settings.data]);
 
-  useEffect(() => {
-    updateStorageSettings(settings);
-  }, [settings]);
+  console.log('SETTINGS: ', settings);
 
   return [settings.data, handleSettingsChange];
 };

--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -40,8 +40,9 @@ const getPageSettings = ({
   key,
   assignee,
   type,
+  data,
   cacheList,
-}: Omit<Settings, 'data'> & { cacheList: CacheResponse[] }) => {
+}: Settings & { cacheList: CacheResponse[] }) => {
   console.log('cache list: ', cacheList);
 
   const settingsItem = cacheList.find(
@@ -55,7 +56,7 @@ const getPageSettings = ({
 
   return {
     ...settingsItem,
-    data: JSON.parse(settingsItem.data),
+    data: settingsItem ? JSON.parse(settingsItem.data) : data,
   };
 };
 
@@ -135,7 +136,13 @@ export const useSettingsStorage = ({ key, assignee, type, data }: Settings) => {
 
   useEffect(() => {
     setSettingsState(
-      getPageSettings({ key, type, assignee, cacheList: cachedData || [] }),
+      getPageSettings({
+        key,
+        type,
+        assignee,
+        data,
+        cacheList: cachedData || [],
+      }),
     );
   }, [cachedData]);
 

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -61,6 +61,8 @@ export interface ModuleProps {
   onFetchError?: (error: unknown) => void;
   filterCallback?: (filter: unknown) => void;
   externalSearch?: Search;
+  filterSettingsId?: string;
+  filterSettingsCacheUri?: string;
 }
 
 const CrudModule = (props: ModuleProps) => {
@@ -153,6 +155,8 @@ const CrudModule = (props: ModuleProps) => {
           hideDetailsButton={!props.detailsFormProps}
           filterCallback={props.filterCallback}
           externalSearch={props.externalSearch}
+          filterSettingsId={props.filterSettingsId}
+          filterSettingsCacheUri={props.filterSettingsCacheUri}
           {...useTableReturn}
           {...tableSubmoduleProps}
         />


### PR DESCRIPTION
### [Save Column and Filter settings to database](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1633)

This PR integrates the visibility and order settings from the Filter and ComposedTable components with the database through endpoints available at the Cache Module. 