### PR TITLE
Implement Breadcrumbs component

### DIFF
--- a/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
+++ b/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Breadcrumbs from '../src/components/Breadcrumbs';
+
+describe('Dialog Component', () => {
+  it('should render correctly', () => {
+    const { debug } = render(<Breadcrumbs />);
+
+    debug();
+  });
+});

--- a/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
+++ b/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
@@ -8,10 +8,52 @@ import { render } from '@testing-library/react';
 
 import Breadcrumbs from '../src/components/Breadcrumbs';
 
-describe('Dialog Component', () => {
-  it('should render correctly', () => {
-    const { debug } = render(<Breadcrumbs />);
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/route-1/route-2',
+}));
 
-    debug();
+describe('Dialog Component', () => {
+  const customPathname = '/test1/test2';
+
+  it('should render correctly without props', () => {
+    render(<Breadcrumbs />);
+  });
+
+  it('should render correctly with props', () => {
+    render(<Breadcrumbs customPathname={customPathname} />);
+  });
+
+  it('should render correctly without props', () => {
+    const { queryAllByRole } = render(<Breadcrumbs />);
+
+    const listItems = queryAllByRole('listitem');
+
+    expect(listItems).toHaveLength(2);
+  });
+
+  it('should render correctly with props', () => {
+    const { queryAllByRole } = render(
+      <Breadcrumbs customPathname={customPathname} />,
+    );
+
+    const listItems = queryAllByRole('listitem');
+
+    expect(listItems).toHaveLength(2);
+  });
+
+  it('should render correct tags without props', () => {
+    const { getByText } = render(<Breadcrumbs />);
+
+    expect(getByText('Route 1')).toBeInTheDocument();
+    expect(getByText('Route 2')).toBeInTheDocument();
+  });
+
+  it('should render correct tags with props', () => {
+    const { getByText } = render(
+      <Breadcrumbs customPathname={customPathname} />,
+    );
+
+    expect(getByText('Test1')).toBeInTheDocument();
+    expect(getByText('Test2')).toBeInTheDocument();
   });
 });

--- a/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,36 +6,40 @@ import {
   Stack,
 } from '@mui/material';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { usePathname } from 'next/navigation';
 
-function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
-  event.preventDefault();
-  console.info('You clicked a breadcrumb.');
-}
+import { transformRouteIntoLabel } from './utils';
 
-export default function Breadcrumbs() {
-  const breadcrumbs = [
-    <Link
-      underline="hover"
-      key="1"
-      color="inherit"
-      href="/"
-      onClick={handleClick}
-    >
-      MUI
-    </Link>,
-    <Link
-      underline="hover"
-      key="2"
-      color="inherit"
-      href="/material-ui/getting-started/installation/"
-      onClick={handleClick}
-    >
-      Core
-    </Link>,
-    <Typography key="3" color="text.primary">
-      Breadcrumb
-    </Typography>,
-  ];
+type Props = {
+  customPathname?: string;
+};
+
+export default function Breadcrumbs({ customPathname }: Props) {
+  const pathname = usePathname();
+
+  const transformedPath = React.useMemo(() => {
+    return (customPathname || pathname).slice(1).split('/');
+  }, [pathname, customPathname]);
+
+  const routeObjects = React.useMemo(() => {
+    return transformedPath.map((item) => ({
+      route: `/${item}`,
+      label: transformRouteIntoLabel(item),
+    }));
+  }, [transformedPath]);
+
+  const breadcrumbs = routeObjects.slice(0, -1).map((route, index) => {
+    return (
+      <Link
+        underline="hover"
+        key={index + 1}
+        color="inherit"
+        href={route.route}
+      >
+        {route.label}
+      </Link>
+    );
+  });
 
   return (
     <Stack spacing={2}>
@@ -44,6 +48,9 @@ export default function Breadcrumbs() {
         aria-label="breadcrumbs"
       >
         {breadcrumbs}
+        <Typography key={transformedPath.length} color="text.primary">
+          {transformRouteIntoLabel(transformedPath.slice(-1)[0])}
+        </Typography>
       </MuiBreadcrumbs>
     </Stack>
   );

--- a/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import {
+  Breadcrumbs as MuiBreadcrumbs,
+  Typography,
+  Link,
+  Stack,
+} from '@mui/material';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+
+function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
+  event.preventDefault();
+  console.info('You clicked a breadcrumb.');
+}
+
+export default function Breadcrumbs() {
+  const breadcrumbs = [
+    <Link
+      underline="hover"
+      key="1"
+      color="inherit"
+      href="/"
+      onClick={handleClick}
+    >
+      MUI
+    </Link>,
+    <Link
+      underline="hover"
+      key="2"
+      color="inherit"
+      href="/material-ui/getting-started/installation/"
+      onClick={handleClick}
+    >
+      Core
+    </Link>,
+    <Typography key="3" color="text.primary">
+      Breadcrumb
+    </Typography>,
+  ];
+
+  return (
+    <Stack spacing={2}>
+      <MuiBreadcrumbs
+        separator={<NavigateNextIcon fontSize="small" />}
+        aria-label="breadcrumbs"
+      >
+        {breadcrumbs}
+      </MuiBreadcrumbs>
+    </Stack>
+  );
+}

--- a/packages/react-material-ui/src/components/Breadcrumbs/index.ts
+++ b/packages/react-material-ui/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Breadcrumbs';

--- a/packages/react-material-ui/src/components/Breadcrumbs/utils.ts
+++ b/packages/react-material-ui/src/components/Breadcrumbs/utils.ts
@@ -1,0 +1,7 @@
+export const capitalizeString = (value: string) => {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
+export const transformRouteIntoLabel = (route: string) => {
+  return capitalizeString(route.split('-').join(' '));
+};

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,284 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.3.1'
+const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    const headers = Object.fromEntries(requestClone.headers.entries())
+
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}


### PR DESCRIPTION
### [Implement Breadcrumbs component based on route history](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1647)

Implementation of Breadcumbs component for route history. The base component is imported from MUI and uses the next/navigation pathname as default for route slicing. Also, a custom pathname can be passed as props.