### PR TITLE
Implement Breadcrumbs component

### DIFF
--- a/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
+++ b/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Breadcrumbs from '../src/components/Breadcrumbs';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/route-1/route-2',
+}));
+
+describe('Dialog Component', () => {
+  const customPathname = '/test1/test2';
+
+  it('should render correctly without props', () => {
+    render(<Breadcrumbs />);
+  });
+
+  it('should render correctly with props', () => {
+    render(<Breadcrumbs customPathname={customPathname} />);
+  });
+
+  it('should render correctly without props', () => {
+    const { queryAllByRole } = render(<Breadcrumbs />);
+
+    const listItems = queryAllByRole('listitem');
+
+    expect(listItems).toHaveLength(2);
+  });
+
+  it('should render correctly with props', () => {
+    const { queryAllByRole } = render(
+      <Breadcrumbs customPathname={customPathname} />,
+    );
+
+    const listItems = queryAllByRole('listitem');
+
+    expect(listItems).toHaveLength(2);
+  });
+
+  it('should render correct tags without props', () => {
+    const { getByText } = render(<Breadcrumbs />);
+
+    expect(getByText('Route 1')).toBeInTheDocument();
+    expect(getByText('Route 2')).toBeInTheDocument();
+  });
+
+  it('should render correct tags with props', () => {
+    const { getByText } = render(
+      <Breadcrumbs customPathname={customPathname} />,
+    );
+
+    expect(getByText('Test1')).toBeInTheDocument();
+    expect(getByText('Test2')).toBeInTheDocument();
+  });
+});

--- a/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
+++ b/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
@@ -8,52 +8,28 @@ import { render } from '@testing-library/react';
 
 import Breadcrumbs from '../src/components/Breadcrumbs';
 
-jest.mock('next/navigation', () => ({
-  usePathname: () => '/route-1/route-2',
-}));
-
 describe('Dialog Component', () => {
-  const customPathname = '/test1/test2';
+  const routes = [
+    { href: '/', label: 'Home' },
+    { href: '/users', label: 'Users' },
+  ];
 
-  it('should render correctly without props', () => {
-    render(<Breadcrumbs />);
+  it('should render correctly', () => {
+    render(<Breadcrumbs routes={routes} />);
   });
 
-  it('should render correctly with props', () => {
-    render(<Breadcrumbs customPathname={customPathname} />);
-  });
-
-  it('should render correctly without props', () => {
-    const { queryAllByRole } = render(<Breadcrumbs />);
+  it('should render correct number of list items', () => {
+    const { queryAllByRole } = render(<Breadcrumbs routes={routes} />);
 
     const listItems = queryAllByRole('listitem');
 
     expect(listItems).toHaveLength(2);
   });
 
-  it('should render correctly with props', () => {
-    const { queryAllByRole } = render(
-      <Breadcrumbs customPathname={customPathname} />,
-    );
+  it('should render correct text items', () => {
+    const { getByText } = render(<Breadcrumbs routes={routes} />);
 
-    const listItems = queryAllByRole('listitem');
-
-    expect(listItems).toHaveLength(2);
-  });
-
-  it('should render correct tags without props', () => {
-    const { getByText } = render(<Breadcrumbs />);
-
-    expect(getByText('Route 1')).toBeInTheDocument();
-    expect(getByText('Route 2')).toBeInTheDocument();
-  });
-
-  it('should render correct tags with props', () => {
-    const { getByText } = render(
-      <Breadcrumbs customPathname={customPathname} />,
-    );
-
-    expect(getByText('Test1')).toBeInTheDocument();
-    expect(getByText('Test2')).toBeInTheDocument();
+    expect(getByText('Home')).toBeInTheDocument();
+    expect(getByText('Users')).toBeInTheDocument();
   });
 });

--- a/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
+++ b/packages/react-material-ui/__tests__/Breadcrumbs.spec.tsx
@@ -8,7 +8,7 @@ import { render } from '@testing-library/react';
 
 import Breadcrumbs from '../src/components/Breadcrumbs';
 
-describe('Dialog Component', () => {
+describe('Breadcrumbs Component', () => {
   const routes = [
     { href: '/', label: 'Home' },
     { href: '/users', label: 'Users' },
@@ -16,6 +16,14 @@ describe('Dialog Component', () => {
 
   it('should render correctly', () => {
     render(<Breadcrumbs routes={routes} />);
+  });
+
+  it('should render null when routes array is empty', () => {
+    const { queryAllByRole } = render(<Breadcrumbs routes={[]} />);
+
+    const listItems = queryAllByRole('listitem');
+
+    expect(listItems).toHaveLength(0);
   });
 
   it('should render correct number of list items', () => {

--- a/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useMemo } from 'react';
 import {
   Breadcrumbs as MuiBreadcrumbs,
   Typography,
@@ -6,40 +6,41 @@ import {
   Stack,
 } from '@mui/material';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import { usePathname } from 'next/navigation';
 
-import { transformRouteIntoLabel } from './utils';
-
-type Props = {
-  customPathname?: string;
+type RouteItem = {
+  href: string;
+  label: string;
 };
 
-export default function Breadcrumbs({ customPathname }: Props) {
-  const pathname = usePathname();
+type Props = {
+  routes: RouteItem[];
+};
 
-  const transformedPath = React.useMemo(() => {
-    return (customPathname || pathname).slice(1).split('/');
-  }, [pathname, customPathname]);
+export default function Breadcrumbs({ routes }: Props) {
+  const breadcrumbs = useMemo(() => {
+    return routes.slice(0, -1).map((routeItem, index) => {
+      return (
+        <Link
+          underline="hover"
+          key={index + 1}
+          color="inherit"
+          href={routeItem.href}
+        >
+          {routeItem.label}
+        </Link>
+      );
+    });
+  }, [routes]);
 
-  const routeObjects = React.useMemo(() => {
-    return transformedPath.map((item) => ({
-      route: `/${item}`,
-      label: transformRouteIntoLabel(item),
-    }));
-  }, [transformedPath]);
+  const lastItem = useMemo(() => {
+    const data = routes.at(-1);
 
-  const breadcrumbs = routeObjects.slice(0, -1).map((route, index) => {
-    return (
-      <Link
-        underline="hover"
-        key={index + 1}
-        color="inherit"
-        href={route.route}
-      >
-        {route.label}
-      </Link>
-    );
-  });
+    if (!data) {
+      return null;
+    }
+
+    return <Typography color="text.primary">{data.label}</Typography>;
+  }, []);
 
   return (
     <Stack spacing={2}>
@@ -48,9 +49,7 @@ export default function Breadcrumbs({ customPathname }: Props) {
         aria-label="breadcrumbs"
       >
         {breadcrumbs}
-        <Typography key={transformedPath.length} color="text.primary">
-          {transformRouteIntoLabel(transformedPath.slice(-1)[0])}
-        </Typography>
+        {lastItem}
       </MuiBreadcrumbs>
     </Stack>
   );

--- a/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {
+  Breadcrumbs as MuiBreadcrumbs,
+  Typography,
+  Link,
+  Stack,
+} from '@mui/material';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { usePathname } from 'next/navigation';
+
+import { transformRouteIntoLabel } from './utils';
+
+type Props = {
+  customPathname?: string;
+};
+
+export default function Breadcrumbs({ customPathname }: Props) {
+  const pathname = usePathname();
+
+  const transformedPath = React.useMemo(() => {
+    return (customPathname || pathname).slice(1).split('/');
+  }, [pathname, customPathname]);
+
+  const routeObjects = React.useMemo(() => {
+    return transformedPath.map((item) => ({
+      route: `/${item}`,
+      label: transformRouteIntoLabel(item),
+    }));
+  }, [transformedPath]);
+
+  const breadcrumbs = routeObjects.slice(0, -1).map((route, index) => {
+    return (
+      <Link
+        underline="hover"
+        key={index + 1}
+        color="inherit"
+        href={route.route}
+      >
+        {route.label}
+      </Link>
+    );
+  });
+
+  return (
+    <Stack spacing={2}>
+      <MuiBreadcrumbs
+        separator={<NavigateNextIcon fontSize="small" />}
+        aria-label="breadcrumbs"
+      >
+        {breadcrumbs}
+        <Typography key={transformedPath.length} color="text.primary">
+          {transformRouteIntoLabel(transformedPath.slice(-1)[0])}
+        </Typography>
+      </MuiBreadcrumbs>
+    </Stack>
+  );
+}

--- a/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
   Breadcrumbs as MuiBreadcrumbs,
   Typography,
@@ -17,30 +17,23 @@ type Props = {
 };
 
 export default function Breadcrumbs({ routes }: Props) {
-  const breadcrumbs = useMemo(() => {
-    return routes.slice(0, -1).map((routeItem, index) => {
-      return (
-        <Link
-          underline="hover"
-          key={index + 1}
-          color="inherit"
-          href={routeItem.href}
-        >
-          {routeItem.label}
-        </Link>
-      );
-    });
-  }, [routes]);
+  const breadcrumbs = routes.slice(0, -1).map((routeItem, index) => {
+    return (
+      <Link
+        underline="hover"
+        key={index + 1}
+        color="inherit"
+        href={routeItem.href}
+      >
+        {routeItem.label}
+      </Link>
+    );
+  });
+  const lastItem = routes.at(-1);
 
-  const lastItem = useMemo(() => {
-    const data = routes.at(-1);
-
-    if (!data) {
-      return null;
-    }
-
-    return <Typography color="text.primary">{data.label}</Typography>;
-  }, []);
+  if (!routes.length) {
+    return null;
+  }
 
   return (
     <Stack spacing={2}>
@@ -49,7 +42,9 @@ export default function Breadcrumbs({ routes }: Props) {
         aria-label="breadcrumbs"
       >
         {breadcrumbs}
-        {lastItem}
+        {lastItem ? (
+          <Typography color="text.primary">{lastItem.label}</Typography>
+        ) : null}
       </MuiBreadcrumbs>
     </Stack>
   );

--- a/packages/react-material-ui/src/components/Breadcrumbs/index.ts
+++ b/packages/react-material-ui/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Breadcrumbs';

--- a/packages/react-material-ui/src/components/Breadcrumbs/utils.ts
+++ b/packages/react-material-ui/src/components/Breadcrumbs/utils.ts
@@ -1,0 +1,7 @@
+export const capitalizeString = (value: string) => {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
+export const transformRouteIntoLabel = (route: string) => {
+  return capitalizeString(route.split('-').join(' '));
+};

--- a/packages/react-material-ui/src/components/Breadcrumbs/utils.ts
+++ b/packages/react-material-ui/src/components/Breadcrumbs/utils.ts
@@ -1,7 +1,0 @@
-export const capitalizeString = (value: string) => {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-};
-
-export const transformRouteIntoLabel = (route: string) => {
-  return capitalizeString(route.split('-').join(' '));
-};

--- a/packages/react-material-ui/src/index.ts
+++ b/packages/react-material-ui/src/index.ts
@@ -57,3 +57,5 @@ export { default as CrudModule } from './modules/crud';
 export { default as UsersModule } from './modules/users';
 
 export { default as OtpInput } from './components/OtpInput';
+
+export { default as Breadcrumbs } from './components/Breadcrumbs';

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -18,6 +18,7 @@ import ModalFormSubmodule from '../../components/submodules/ModalForm';
 import { Search } from '../../components/Table/types';
 import CrudRoot from './CrudRoot';
 import { FilterDetails } from '../../components/submodules/Filter';
+import Breadcrumbs from '../../components/Breadcrumbs/Breadcrumbs';
 
 type Action = 'creation' | 'edit' | 'details' | null;
 
@@ -121,6 +122,13 @@ const CrudModule = (props: ModuleProps) => {
       externalSearch={props.externalSearch}
     >
       <Box>
+        <Breadcrumbs
+          routes={[
+            { href: '/', label: 'Home' },
+            { href: '#', label: props.title || 'Table' },
+          ]}
+        />
+
         {props.title ? (
           <Text fontFamily="Inter" fontSize={20} fontWeight={800} mt={4} mb={4}>
             {props.title}

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -122,12 +122,14 @@ const CrudModule = (props: ModuleProps) => {
       externalSearch={props.externalSearch}
     >
       <Box>
-        <Breadcrumbs
-          routes={[
-            { href: '/', label: 'Home' },
-            { href: '#', label: props.title || 'Table' },
-          ]}
-        />
+        <Box mt={4}>
+          <Breadcrumbs
+            routes={[
+              { href: '/', label: 'Home' },
+              { href: '#', label: props.title || 'Table' },
+            ]}
+          />
+        </Box>
 
         {props.title ? (
           <Text fontFamily="Inter" fontSize={20} fontWeight={800} mt={4} mb={4}>


### PR DESCRIPTION
### [Implement Breadcrumbs component based on route history](https://sprints.zoho.com/workspace/conceptatech#P112/itemdetails/I1647)

Implementation of Breadcumbs component for route history using MUI's component. The routes should be passed as props, structured as an array of objects, each one containing `href` and `label`.

<img width="1440" alt="Screenshot 2024-07-17 at 21 52 47" src="https://github.com/user-attachments/assets/99a4cb3c-f626-416c-bee6-d2cbdc23b3d6">
