### PR TITLE
Adjust custom button props on SchemaForm

### DIFF
--- a/packages/react-material-ui/__tests__/CrudModule.spec.tsx
+++ b/packages/react-material-ui/__tests__/CrudModule.spec.tsx
@@ -253,13 +253,16 @@ describe('CrudModule Component', () => {
   });
 
   it('should hide edit icon if editFormProps is not passed', () => {
-    const _props = { ...props, editFormProps: undefined };
+    const { editFormProps, ...restProps } = props;
 
-    const { container, queryAllByTestId } = render(<CrudModule {..._props} />);
+    const { container, queryAllByTestId } = render(
+      <CrudModule {...restProps} />,
+    );
+
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const editIcons = queryAllByTestId('EditIcon');
+    const editIcons = queryAllByTestId('edit-button');
     expect(editIcons).toHaveLength(0);
   });
 
@@ -270,7 +273,7 @@ describe('CrudModule Component', () => {
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const editIcons = queryAllByTestId('EditIcon');
+    const editIcons = queryAllByTestId('edit-button');
 
     editIcons[0] && fireEvent.click(editIcons[0]);
 
@@ -294,7 +297,7 @@ describe('CrudModule Component', () => {
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const editIcons = queryAllByTestId('EditIcon');
+    const editIcons = queryAllByTestId('edit-button');
 
     editIcons[0] && fireEvent.click(editIcons[0]);
 
@@ -311,7 +314,7 @@ describe('CrudModule Component', () => {
     const _props = { ...props, detailsFormProps: undefined };
     const { queryAllByTestId } = render(<CrudModule {..._props} />);
 
-    const chevronRightIcons = queryAllByTestId('ChevronRightIcon');
+    const chevronRightIcons = queryAllByTestId('details-button');
     expect(chevronRightIcons).toHaveLength(0);
   });
 
@@ -322,7 +325,7 @@ describe('CrudModule Component', () => {
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const chevronRightIcons = queryAllByTestId('ChevronRightIcon');
+    const chevronRightIcons = queryAllByTestId('details-button');
 
     chevronRightIcons[0] && fireEvent.click(chevronRightIcons[0]);
 
@@ -346,7 +349,7 @@ describe('CrudModule Component', () => {
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const chevronRightIcons = queryAllByTestId('ChevronRightIcon');
+    const chevronRightIcons = queryAllByTestId('details-button');
 
     chevronRightIcons[0] && fireEvent.click(chevronRightIcons[0]);
 

--- a/packages/react-material-ui/__tests__/CrudModule.spec.tsx
+++ b/packages/react-material-ui/__tests__/CrudModule.spec.tsx
@@ -181,9 +181,9 @@ describe('CrudModule Component', () => {
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const editIcons = queryAllByTestId('EditIcon');
-    const deleteIcons = queryAllByTestId('DeleteIcon');
-    const chevronRightIcons = queryAllByTestId('ChevronRightIcon');
+    const editIcons = queryAllByTestId('edit-button');
+    const deleteIcons = queryAllByTestId('delete-button');
+    const chevronRightIcons = queryAllByTestId('details-button');
 
     expect(editIcons).toHaveLength(0);
     expect(deleteIcons).toHaveLength(0);
@@ -197,9 +197,9 @@ describe('CrudModule Component', () => {
     const tableBody = container.querySelector('tbody');
     expect(tableBody).toBeInTheDocument();
 
-    const editIcons = queryAllByTestId('EditIcon');
-    const deleteIcons = queryAllByTestId('DeleteIcon');
-    const chevronRightIcons = queryAllByTestId('ChevronRightIcon');
+    const editIcons = queryAllByTestId('edit-button');
+    const deleteIcons = queryAllByTestId('delete-button');
+    const chevronRightIcons = queryAllByTestId('details-button');
 
     expect(editIcons).toHaveLength(2);
     expect(deleteIcons).toHaveLength(0);

--- a/packages/react-material-ui/__tests__/SchemaForm.spec.tsx
+++ b/packages/react-material-ui/__tests__/SchemaForm.spec.tsx
@@ -69,6 +69,40 @@ describe('SchemaForm Component', () => {
     expect(title).toBeInTheDocument();
   });
 
+  it('renders button title prop correctly', () => {
+    const schema: SchemaFormProps['schema'] = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', title: 'Name' },
+      },
+    };
+    const { getByText } = render(
+      <SchemaForm.Form schema={schema} buttonTitle="Testing"></SchemaForm.Form>,
+    );
+    const title = getByText('Testing');
+    expect(title).toBeInTheDocument();
+  });
+
+  it('renders button component prop correctly', () => {
+    const schema: SchemaFormProps['schema'] = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', title: 'Name' },
+      },
+    };
+    const CustomButton = () => {
+      return <button>Testing</button>;
+    };
+    const { getByText } = render(
+      <SchemaForm.Form
+        schema={schema}
+        buttonComponent={CustomButton}
+      ></SchemaForm.Form>,
+    );
+    const title = getByText('Testing');
+    expect(title).toBeInTheDocument();
+  });
+
   it('shows validation errors if required fields are missing after submit', () => {
     const schema: SchemaFormProps['schema'] = {
       type: 'object',

--- a/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-material-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import {
-  Breadcrumbs as MuiBreadcrumbs,
-  Typography,
-  Link,
-  Stack,
-} from '@mui/material';
+import MuiBreadcrumbs from '@mui/material/Breadcrumbs';
+import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 
 type RouteItem = {

--- a/packages/react-material-ui/src/components/ComposedTable/index.tsx
+++ b/packages/react-material-ui/src/components/ComposedTable/index.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
   useTheme,
 } from '@mui/material';
-import { Settings } from '@mui/icons-material';
+import Settings from '@mui/icons-material/Settings';
 import { useAuth } from '@concepta/react-auth-provider';
 import { usePathname } from 'next/navigation';
 

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { ReactNode, useState } from 'react';
-import { Box, Grid, GridProps } from '@mui/material';
-import { FilterAlt } from '@mui/icons-material';
+import Box from '@mui/material/Box';
+import Grid, { GridProps } from '@mui/material/Grid';
+import FilterAlt from '@mui/icons-material/FilterAlt';
 import { useAuth } from '@concepta/react-auth-provider';
 import { usePathname } from 'next/navigation';
 

--- a/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
+++ b/packages/react-material-ui/src/components/OrderableDropDown/OrderableDropDown.tsx
@@ -31,7 +31,8 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { DragIndicator, SettingsSuggest } from '@mui/icons-material';
+import DragIndicator from '@mui/icons-material/DragIndicator';
+import SettingsSuggest from '@mui/icons-material/SettingsSuggest';
 
 export interface ListItem {
   id: string;

--- a/packages/react-material-ui/src/components/SchemaForm/SchemaForm.tsx
+++ b/packages/react-material-ui/src/components/SchemaForm/SchemaForm.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import React, { Fragment, ReactNode } from 'react';
+import React, { Fragment, ReactNode, ComponentType } from 'react';
 import validator from '@rjsf/validator-ajv6';
 import RJSFForm from '@rjsf/mui';
 import Box from '@mui/material/Box';
-import { RJSFSchema } from '@rjsf/utils';
+import { RJSFSchema, SubmitButtonProps } from '@rjsf/utils';
 import { FormProps } from '@rjsf/core';
 
 import { mapAdvancedProperties } from './utils/mapAdvancedProperties';
@@ -29,7 +29,7 @@ export type SchemaFormProps = Omit<FormProps, 'schema' | 'validator'> & {
   /**
    * Validation helper for the form structure. `@rjsf/validator-ajvx` provided by
    * [ajv](https://github.com/ajv-validator/ajv), is generally used for this purpose.
-   * 
+   *
    * It is implemented on the form via the
    * [HTML5 Validation](https://rjsf-team.github.io/react-jsonschema-form/docs/usage/validation#html5-validation)
    */
@@ -37,7 +37,7 @@ export type SchemaFormProps = Omit<FormProps, 'schema' | 'validator'> & {
   /**
    * Additional schema for fields that are out of the default `string`, `number`,
    * `integer`, `object`, `array`, `boolean` and `null` set for the form schema.
-   * 
+   *
    * The field set for advanced properties contain the same types as the default
    * one, but add other fields such as `email`, `password`, `select`, `radio`,
    * `checkbox`, `checkboxes` and `switch`.
@@ -50,19 +50,19 @@ export type SchemaFormProps = Omit<FormProps, 'schema' | 'validator'> & {
   /**
    * Custom component for the form submit button
    */
-  buttonComponent?: ReactNode;
+  buttonComponent?: ComponentType<SubmitButtonProps<any, RJSFSchema, any>>;
   /**
    * The title of the form, usually displayed on top of the fields
    */
   title?: ReactNode;
   /**
    * Custom mapper for the advanced properties.
-   * 
+   *
    * The default mapper for the form component is described
    * in the example below.
-   * 
+   *
    * The rest of the SchemaForm props extend from [react-jsonschema-form](https://rjsf-team.github.io/react-jsonschema-form/docs/).
-   * 
+   *
    * @example
    * ```json
    * {
@@ -167,11 +167,24 @@ const Form = ({
             uiSchema={{
               ...uiSchemaGenerator(finalSchema, advancedProperties),
               ...uiSchema,
+              ...(props.buttonTitle && {
+                'ui:submitButtonOptions': {
+                  submitText: props.buttonTitle,
+                },
+              }),
             }}
             formData={mergeFormData(finalSchema, formData)}
             noHtml5Validate
             showErrorList={false}
-            templates={{ ArrayFieldTemplate, ObjectFieldTemplate }}
+            templates={{
+              ArrayFieldTemplate,
+              ObjectFieldTemplate,
+              ...(props.buttonComponent && {
+                ButtonTemplates: {
+                  SubmitButton: props.buttonComponent,
+                },
+              }),
+            }}
             validator={validator}
             {...props}
           >

--- a/packages/react-material-ui/src/components/SchemaForm/SchemaForm.tsx
+++ b/packages/react-material-ui/src/components/SchemaForm/SchemaForm.tsx
@@ -158,33 +158,47 @@ const Form = ({
     properties: advancedPropertiesMapper(schema, advancedProperties),
   };
 
+  const uiSchemaWithButtonTitle = {
+    ...uiSchemaGenerator(finalSchema, advancedProperties),
+    ...uiSchema,
+    'ui:submitButtonOptions': {
+      submitText: props.buttonTitle,
+    },
+  };
+
+  const templatesWithCustomButton = {
+    ArrayFieldTemplate,
+    ObjectFieldTemplate,
+    ButtonTemplates: {
+      SubmitButton: props.buttonComponent,
+    },
+  };
+
   return (
     <Fragment>
       {schema && (
         <Box>
           <RJSFForm
             schema={finalSchema}
-            uiSchema={{
-              ...uiSchemaGenerator(finalSchema, advancedProperties),
-              ...uiSchema,
-              ...(props.buttonTitle && {
-                'ui:submitButtonOptions': {
-                  submitText: props.buttonTitle,
-                },
-              }),
-            }}
+            uiSchema={
+              props.buttonTitle
+                ? uiSchemaWithButtonTitle
+                : {
+                    ...uiSchemaGenerator(finalSchema, advancedProperties),
+                    ...uiSchema,
+                  }
+            }
             formData={mergeFormData(finalSchema, formData)}
             noHtml5Validate
             showErrorList={false}
-            templates={{
-              ArrayFieldTemplate,
-              ObjectFieldTemplate,
-              ...(props.buttonComponent && {
-                ButtonTemplates: {
-                  SubmitButton: props.buttonComponent,
-                },
-              }),
-            }}
+            templates={
+              props.buttonComponent
+                ? templatesWithCustomButton
+                : {
+                    ArrayFieldTemplate,
+                    ObjectFieldTemplate,
+                  }
+            }
             validator={validator}
             {...props}
           >

--- a/packages/react-material-ui/src/components/SearchField/SearchField.tsx
+++ b/packages/react-material-ui/src/components/SearchField/SearchField.tsx
@@ -15,7 +15,7 @@ import {
   TextField,
   TextFieldProps,
 } from '@mui/material';
-import { Clear } from '@mui/icons-material';
+import Clear from '@mui/icons-material/Clear';
 
 const SearchIcon = () => (
   <MuiSearchIcon

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -11,7 +11,7 @@ import {
   DialogContent,
   IconButton,
 } from '@mui/material';
-import { Close as CloseIcon } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import validator from '@rjsf/validator-ajv6';
 

--- a/packages/react-material-ui/src/components/submodules/Table/MobileRowModal.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/MobileRowModal.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import { Tooltip, Box, Dialog, DialogContent, IconButton } from '@mui/material';
-import { Close as CloseIcon } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
 
 import Text from '../../Text';
 import { CustomTableCell, RowProps } from '../../Table/types';

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -199,6 +199,7 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
                       props.onAction({ action: 'edit', row: rowData });
                     }
                   }}
+                  data-testid="edit-button"
                 >
                   <EditIcon />
                 </IconButton>
@@ -210,6 +211,7 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
                     e.stopPropagation();
                     deleteItem(rowData.id);
                   }}
+                  data-testid="delete-button"
                 >
                   <DeleteIcon />
                 </IconButton>
@@ -223,6 +225,7 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
                       props.onAction({ action: 'details', row: rowData });
                     }
                   }}
+                  data-testid="details-button"
                 >
                   <ChevronRightIcon />
                 </IconButton>

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -21,12 +21,10 @@ import {
   Theme,
   SxProps,
 } from '@mui/material';
-import {
-  Edit as EditIcon,
-  Delete as DeleteIcon,
-  ChevronRight as ChevronRightIcon,
-  Add as AddIcon,
-} from '@mui/icons-material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Edit';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import AddIcon from '@mui/icons-material/Add';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import get from 'lodash/get';
 


### PR DESCRIPTION
Theis PR adjusts the `buttonTitle` and `buttonComponent` props from SchemaForm component, in a way that it is passed correctly to the RJSF form, `buttonTitle` being part of the `uiSchema` and `buttonComponent` being a custom template.

The changes also include adjustments on the `Avatar` component import and renaming icon props so the compile time in child projects get optimized.

### Form component with just a schema prop
<img width="708" alt="Screenshot 2024-07-23 at 17 46 15" src="https://github.com/user-attachments/assets/744679cc-2f21-41df-a74f-459e6820dd53">

### Form component with CUSTOM TITLE passed via `buttonTitle` prop
<img width="708" alt="Screenshot 2024-07-23 at 17 46 37" src="https://github.com/user-attachments/assets/9e9dd66d-a51e-4925-848a-6ae8de66e361">

### Form component with CUSTOM OUTLINED BUTTON passed via `buttonComponent` prop
<img width="708" alt="Screenshot 2024-07-23 at 17 49 03" src="https://github.com/user-attachments/assets/10f842de-106f-4099-8007-d310018f734d">

