### PR TITLE
Add page prop to DefaultRoute

### DIFF
--- a/packages/react-material-ui/src/components/submodules/AuthForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/AuthForm/index.tsx
@@ -80,7 +80,7 @@ const AuthFormSubmodule = (props: AuthFormSubmoduleProps) => {
   const [formData, setFormData] = useState<Record<string, unknown>>({});
 
   const searchParams = new URLSearchParams(window.location.search);
-  const passcode = '';
+  const passcode = searchParams?.get('token');
 
   const { post, patch, put } = useDataProvider();
   const { doLogin, isPending: isLoadingSignIn } = useAuth();

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -22,7 +22,7 @@ import {
   SxProps,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import AddIcon from '@mui/icons-material/Add';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';

--- a/packages/react-navigation/src/components/DefaultRoute.tsx
+++ b/packages/react-navigation/src/components/DefaultRoute.tsx
@@ -8,7 +8,8 @@ import { ModuleProps } from '@concepta/react-material-ui/dist/modules/crud';
 type DefaultRouteProps = {
   resource: string;
   name: string;
-  module: ModuleProps;
+  module?: ModuleProps;
+  page?: ReactNode;
   items: DrawerItemProps[];
   renderAppBar?: (
     menuItems: DrawerItemProps[],
@@ -20,6 +21,7 @@ const DefaultRoute = ({
   resource,
   name,
   module,
+  page,
   items,
   renderAppBar,
 }: DefaultRouteProps) => {
@@ -33,18 +35,27 @@ const DefaultRoute = ({
     },
   }));
 
+  let renderedChildren = null;
+
+  if (page) {
+    renderedChildren = page;
+  }
+
+  if (module) {
+    renderedChildren = (
+      <CrudModule
+        {...module}
+        resource={resource}
+        title={name}
+        navigate={navigate}
+      />
+    );
+  }
+
   if (renderAppBar) {
     return (
       <ProtectedRoute>
-        {renderAppBar(
-          menuItems,
-          <CrudModule
-            {...module}
-            resource={resource}
-            title={name}
-            navigate={navigate}
-          />,
-        )}
+        {renderAppBar(menuItems, renderedChildren)}
       </ProtectedRoute>
     );
   }
@@ -52,12 +63,7 @@ const DefaultRoute = ({
   return (
     <ProtectedRoute>
       <AppBarContainer menuItems={menuItems}>
-        <CrudModule
-          {...module}
-          resource={resource}
-          title={name}
-          navigate={navigate}
-        />
+        {renderedChildren}
       </AppBarContainer>
     </ProtectedRoute>
   );

--- a/packages/react-navigation/src/components/Resource.tsx
+++ b/packages/react-navigation/src/components/Resource.tsx
@@ -6,7 +6,8 @@ type ResourceProps = {
   id: string;
   name: string;
   icon: ReactNode;
-  module: Partial<ModuleProps>;
+  module?: Partial<ModuleProps>;
+  page?: ReactNode;
 };
 
 const Resource = ({ id }: ResourceProps) => {

--- a/packages/react-navigation/src/components/RoutesRoot.tsx
+++ b/packages/react-navigation/src/components/RoutesRoot.tsx
@@ -29,7 +29,7 @@ const RoutesRoot = ({ routes, items, renderAppBar }: RoutesRootProps) => {
             element={
               <DefaultRoute
                 renderAppBar={renderAppBar}
-                resource={child.props.id}
+                resource={child.props?.module?.resource}
                 name={child.props.name}
                 items={items}
                 module={child.props.module}

--- a/packages/react-navigation/src/components/RoutesRoot.tsx
+++ b/packages/react-navigation/src/components/RoutesRoot.tsx
@@ -33,6 +33,7 @@ const RoutesRoot = ({ routes, items, renderAppBar }: RoutesRootProps) => {
                 name={child.props.name}
                 items={items}
                 module={child.props.module}
+                page={child.props.page}
               />
             }
           />

--- a/packages/react-navigation/src/components/RoutesRoot.tsx
+++ b/packages/react-navigation/src/components/RoutesRoot.tsx
@@ -29,7 +29,7 @@ const RoutesRoot = ({ routes, items, renderAppBar }: RoutesRootProps) => {
             element={
               <DefaultRoute
                 renderAppBar={renderAppBar}
-                resource={child.props?.module?.resource}
+                resource={child.props.id}
                 name={child.props.name}
                 items={items}
                 module={child.props.module}


### PR DESCRIPTION
Add `page` prop to DefaultRoute, in a way that a custom node can be rendered instead of a module on Resource instances.