### PR TITLE
feat: rename defaultRoute to initialRoute and fix prop drilling

### DIFF
--- a/packages/react-material-ui/src/styles/CustomWidgets/CustomCheckboxWidget.tsx
+++ b/packages/react-material-ui/src/styles/CustomWidgets/CustomCheckboxWidget.tsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Checkbox } from '../../components/Checkbox';
 import { WidgetProps } from '@rjsf/utils';
 
-const CustomCheckboxWidget = (props: WidgetProps) => (
+type CustomCheckboxWidgetProps = WidgetProps & {
+  label: string | ReactNode;
+};
+
+const CustomCheckboxWidget = (props: CustomCheckboxWidgetProps) => (
   <Checkbox
     checked={props.value}
     label={props.label}

--- a/packages/react-navigation/src/components/DefaultRoute.tsx
+++ b/packages/react-navigation/src/components/DefaultRoute.tsx
@@ -13,7 +13,9 @@ import { ModuleProps } from '@concepta/react-material-ui/dist/modules/crud';
 type DefaultRouteProps = {
   resource: string;
   name: string;
+  useNavigateFilter?: boolean;
   isUnprotected?: boolean;
+  showAppBar?: boolean;
   module?: ModuleProps;
   page?: ReactNode;
   items: DrawerItemProps[];
@@ -28,74 +30,58 @@ type DefaultRouteProps = {
 const DefaultRoute = ({
   resource,
   name,
+  useNavigateFilter = true,
   isUnprotected = false,
+  showAppBar = true,
   module,
   page,
   items,
   drawerProps,
   navbarProps,
   renderAppBar,
-}: DefaultRouteProps) => {
+}: DefaultRouteProps): JSX.Element => {
   const navigate = useNavigate();
-
   const resourceName = resource.substring(1);
 
-  const menuItems = items?.map((item) => ({
+  const menuItems = items.map((item) => ({
     ...item,
-    onClick: () => {
-      if (!item?.id) return;
-      navigate(item.id);
-    },
+    onClick: () => item?.id && navigate(item.id),
   }));
 
-  let renderedChildren = null;
+  const content = module ? (
+    <CrudModule
+      {...module}
+      resource={resourceName}
+      title={name}
+      navigate={useNavigateFilter ? navigate : undefined}
+    />
+  ) : (
+    page
+  );
 
-  if (page) {
-    renderedChildren = page;
-  }
-
-  if (module) {
-    renderedChildren = (
-      <CrudModule
-        {...module}
-        resource={resourceName}
-        title={name}
-        navigate={navigate}
-      />
-    );
-  }
-
-  if (renderAppBar) {
-    if (!isUnprotected) {
-      return <>{renderAppBar(menuItems, renderedChildren)}</>;
-    }
-
-    return (
-      <ProtectedRoute>
-        {renderAppBar(menuItems, renderedChildren)}
-      </ProtectedRoute>
-    );
-  }
-
-  if (!isUnprotected) {
-    return (
-      <AppBarContainer menuItems={menuItems}>
-        {renderedChildren}
-      </AppBarContainer>
-    );
-  }
-
-  return (
-    <ProtectedRoute>
+  const wrappedContent = showAppBar ? (
+    renderAppBar ? (
+      renderAppBar(menuItems, content)
+    ) : (
       <AppBarContainer
         menuItems={menuItems}
         drawerProps={drawerProps}
         navbarProps={navbarProps}
       >
-        {renderedChildren}
+        {content}
       </AppBarContainer>
-    </ProtectedRoute>
+    )
+  ) : (
+    content
   );
+
+  const finalContent = isUnprotected ? (
+    wrappedContent
+  ) : (
+    <ProtectedRoute>{wrappedContent}</ProtectedRoute>
+  );
+
+  return <>{finalContent}</>;
 };
 
 export default DefaultRoute;

--- a/packages/react-navigation/src/components/Resource.tsx
+++ b/packages/react-navigation/src/components/Resource.tsx
@@ -6,7 +6,9 @@ type ResourceProps = {
   id: string;
   name: string;
   icon: ReactNode;
+  showDrawerItem?: boolean;
   isUnprotected?: boolean;
+  showAppBar?: boolean;
   module?: Partial<ModuleProps>;
   page?: ReactNode;
 };

--- a/packages/react-navigation/src/components/Router.tsx
+++ b/packages/react-navigation/src/components/Router.tsx
@@ -31,6 +31,7 @@ const router = (
   AdminProvider: ComponentType<PropsWithChildren<{ home: string }>>,
   routes: ReactElement[],
   items: DrawerItemProps[],
+  useNavigateFilter?: boolean,
   initialRoute?: string,
   authModuleProps?: AuthModule,
   drawerProps?: DrawerProps,
@@ -56,10 +57,11 @@ const router = (
       <Route
         path="/*"
         element={
-          <AdminProvider home={initialRoute ?? firstRoute?.props.id}>
+          <AdminProvider home={firstRoute?.props.id}>
             <RoutesRoot
               routes={routes}
               items={items}
+              useNavigateFilter={useNavigateFilter}
               initialRoute={initialRoute}
               authModuleProps={authModuleProps}
               drawerProps={drawerProps}
@@ -80,6 +82,7 @@ const router = (
 type RouterProps = {
   children: ReactElement[];
   AdminProvider: ComponentType<PropsWithChildren<{ home: string }>>;
+  useNavigateFilter?: boolean;
   initialRoute?: string;
   useMemoryRouter?: boolean;
   authModuleProps?: AuthModule;
@@ -98,6 +101,7 @@ type RouterProps = {
 const Router = ({
   children,
   AdminProvider,
+  useNavigateFilter,
   initialRoute,
   useMemoryRouter = false,
   authModuleProps,
@@ -110,12 +114,21 @@ const Router = ({
   renderResetPassword,
 }: RouterProps) => {
   const items = Children.map(children, (child) => {
+    // This validation is needed so `showDrawerItem`
+    // can be `true` by default
+    if (
+      child.props.showDrawerItem !== undefined &&
+      !child.props.showDrawerItem
+    ) {
+      return null;
+    }
+
     return {
       id: child.props.id,
       text: child.props.name,
       icon: child.props.icon,
     };
-  });
+  }).filter((item) => !!item);
 
   return (
     <RouterProvider
@@ -123,6 +136,7 @@ const Router = ({
         AdminProvider,
         children,
         items,
+        useNavigateFilter,
         initialRoute,
         authModuleProps,
         drawerProps,

--- a/packages/react-navigation/src/components/Router.tsx
+++ b/packages/react-navigation/src/components/Router.tsx
@@ -31,7 +31,7 @@ const router = (
   AdminProvider: ComponentType<PropsWithChildren<{ home: string }>>,
   routes: ReactElement[],
   items: DrawerItemProps[],
-  defaultRoute?: string,
+  initialRoute?: string,
   authModuleProps?: AuthModule,
   drawerProps?: DrawerProps,
   navbarProps?: NavbarProps,
@@ -56,11 +56,11 @@ const router = (
       <Route
         path="/*"
         element={
-          <AdminProvider home={defaultRoute ?? firstRoute?.props.id}>
+          <AdminProvider home={initialRoute ?? firstRoute?.props.id}>
             <RoutesRoot
               routes={routes}
               items={items}
-              defaultRoute={defaultRoute}
+              initialRoute={initialRoute}
               authModuleProps={authModuleProps}
               drawerProps={drawerProps}
               navbarProps={navbarProps}
@@ -80,7 +80,7 @@ const router = (
 type RouterProps = {
   children: ReactElement[];
   AdminProvider: ComponentType<PropsWithChildren<{ home: string }>>;
-  defaultRoute?: string;
+  initialRoute?: string;
   useMemoryRouter?: boolean;
   authModuleProps?: AuthModule;
   drawerProps?: DrawerProps;
@@ -98,7 +98,7 @@ type RouterProps = {
 const Router = ({
   children,
   AdminProvider,
-  defaultRoute,
+  initialRoute,
   useMemoryRouter = false,
   authModuleProps,
   drawerProps,
@@ -123,7 +123,7 @@ const Router = ({
         AdminProvider,
         children,
         items,
-        defaultRoute,
+        initialRoute,
         authModuleProps,
         drawerProps,
         navbarProps,

--- a/packages/react-navigation/src/components/RoutesRoot.tsx
+++ b/packages/react-navigation/src/components/RoutesRoot.tsx
@@ -15,6 +15,7 @@ import { AuthModule } from './Router';
 type RoutesRootProps = {
   items: DrawerItemProps[];
   routes: ReactElement[];
+  useNavigateFilter?: boolean;
   initialRoute?: string;
   authModuleProps?: AuthModule;
   drawerProps?: DrawerProps;
@@ -32,6 +33,7 @@ type RoutesRootProps = {
 const RoutesRoot = ({
   routes,
   items,
+  useNavigateFilter,
   initialRoute,
   authModuleProps,
   drawerProps,
@@ -105,8 +107,10 @@ const RoutesRoot = ({
               <DefaultRoute
                 renderAppBar={renderAppBar}
                 isUnprotected={child.props.isUnprotected}
+                useNavigateFilter={useNavigateFilter}
                 resource={child.props.id}
                 name={child.props.name}
+                showAppBar={child.props.showAppBar}
                 module={child.props.module}
                 page={child.props.page}
                 items={items}

--- a/packages/react-navigation/src/components/RoutesRoot.tsx
+++ b/packages/react-navigation/src/components/RoutesRoot.tsx
@@ -15,7 +15,7 @@ import { AuthModule } from './Router';
 type RoutesRootProps = {
   items: DrawerItemProps[];
   routes: ReactElement[];
-  defaultRoute?: string;
+  initialRoute?: string;
   authModuleProps?: AuthModule;
   drawerProps?: DrawerProps;
   navbarProps?: NavbarProps;
@@ -32,7 +32,7 @@ type RoutesRootProps = {
 const RoutesRoot = ({
   routes,
   items,
-  defaultRoute,
+  initialRoute,
   authModuleProps,
   drawerProps,
   navbarProps,
@@ -42,11 +42,14 @@ const RoutesRoot = ({
   renderForgotPassword,
   renderResetPassword,
 }: RoutesRootProps) => {
-  const home = defaultRoute ?? routes[0].props.id;
+  const home = routes[0].props.id;
 
   return (
     <Routes>
-      <Route path="/" element={<Navigate to={home} replace />} />
+      <Route
+        path="/"
+        element={<Navigate to={initialRoute ?? home} replace />}
+      />
       <Route
         path="/sign-in"
         element={


### PR DESCRIPTION
### About

This PR renames defaultRoute to initialRoute and do not pass it down to authentication components.
It also adds showAppBar, useNavigateFilter, showDrawerItem and expand custom checkbox widget to render string or react node.