### PR TITLE
Adjust flickering CrudModule form buttons and Filter row

### DIFF
--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -1,8 +1,5 @@
-import React, { useState, PropsWithChildren, ReactNode } from 'react';
-
-import type { RJSFSchema, UiSchema, CustomValidator } from '@rjsf/utils';
-import type { IChangeEvent, FormProps } from '@rjsf/core';
-
+import React, { useState } from 'react';
+import type { IChangeEvent } from '@rjsf/core';
 import {
   Box,
   Drawer,
@@ -17,53 +14,11 @@ import CloseIcon from '@mui/icons-material/Close';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import validator from '@rjsf/validator-ajv6';
 
-import { SchemaForm, SchemaFormProps } from '../../../components/SchemaForm';
-
+import { SchemaForm } from '../../../components/SchemaForm';
 import { CustomTextFieldWidget } from '../../../styles/CustomWidgets';
+import { FormSubmoduleProps } from '../types/Form';
 
-type Action = 'creation' | 'edit' | 'details' | null;
-
-type DrawerFormSubmoduleProps = PropsWithChildren<
-  Omit<
-    SchemaFormProps,
-    | 'schema'
-    | 'uiSchema'
-    | 'validator'
-    | 'onSubmit'
-    | 'noHtml5Validate'
-    | 'showErrorList'
-    | 'formData'
-    | 'readonly'
-    | 'customValidate'
-  >
-> & {
-  queryResource: string;
-  title?: string;
-  formSchema?: RJSFSchema;
-  viewMode?: Action | null;
-  formUiSchema?: UiSchema;
-  formData?: Record<string, unknown> | null;
-  submitButtonTitle?: string;
-  cancelButtonTitle?: string;
-  hideCancelButton?: boolean;
-  customFooterContent?: ReactNode;
-  onClose?: () => void;
-  customValidate?: CustomValidator;
-  widgets?: FormProps['widgets'];
-  onSuccess?: (data: unknown) => void;
-  onError?: (error: unknown) => void;
-  onDeleteSuccess?: (data: unknown) => void;
-  onDeleteError?: (error: unknown) => void;
-  onPrevious?: (data: unknown) => void;
-  onNext?: (data: unknown) => void;
-  isLoading?: boolean;
-  viewIndex?: number;
-  rowsPerPage?: number;
-  currentPage?: number;
-  pageCount?: number;
-};
-
-const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
+const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
   const {
     queryResource,
     viewMode,
@@ -87,11 +42,12 @@ const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
     rowsPerPage,
     currentPage,
     pageCount,
+    isVisible,
     ...otherProps
   } = props;
 
   const [fieldValues, setFieldValues] =
-    useState<DrawerFormSubmoduleProps['formData']>(null);
+    useState<FormSubmoduleProps['formData']>(null);
 
   const { post, patch, del } = useDataProvider();
 
@@ -155,7 +111,7 @@ const DrawerFormSubmodule = (props: DrawerFormSubmoduleProps) => {
   };
 
   return (
-    <Drawer open={viewMode !== null} anchor="right">
+    <Drawer open={isVisible} anchor="right">
       <Box
         display="flex"
         alignItems="center"

--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -8,8 +8,6 @@ import {
   IconButton,
   Typography,
 } from '@mui/material';
-import ChevronLeft from '@mui/icons-material/ChevronLeft';
-import ChevronRight from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import validator from '@rjsf/validator-ajv6';
@@ -17,6 +15,7 @@ import validator from '@rjsf/validator-ajv6';
 import { SchemaForm } from '../../../components/SchemaForm';
 import { CustomTextFieldWidget } from '../../../styles/CustomWidgets';
 import { FormSubmoduleProps } from '../types/Form';
+import TableRowControls from '../TableRowControls';
 
 const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
   const {
@@ -181,26 +180,20 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
           }
         >
           {viewMode !== 'creation' && (
-            <Box display="flex" alignItems="center" gap={2}>
-              <IconButton
-                onClick={() => onPrevious(formData)}
-                disabled={isLoading || (currentPage === 1 && viewIndex === 1)}
-              >
-                <ChevronLeft sx={{ color: '#333' }} />
-              </IconButton>
-              <Typography>
-                {isLoading ? '' : `Row ${viewIndex}/${rowsPerPage}`}
-              </Typography>
-              <IconButton
-                onClick={() => onNext(formData)}
-                disabled={
-                  isLoading ||
-                  (currentPage === pageCount && viewIndex === rowsPerPage)
-                }
-              >
-                <ChevronRight sx={{ color: '#333' }} />
-              </IconButton>
-            </Box>
+            <TableRowControls
+              isLoading={isLoading}
+              currentIndex={viewIndex}
+              rowsPerPage={rowsPerPage}
+              isPreviousDisabled={
+                isLoading || (currentPage === 1 && viewIndex === 1)
+              }
+              isNextDisabled={
+                isLoading ||
+                (currentPage === pageCount && viewIndex === rowsPerPage)
+              }
+              onPrevious={() => onPrevious(formData)}
+              onNext={() => onNext(formData)}
+            />
           )}
           <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
             {props.customFooterContent}

--- a/packages/react-material-ui/src/components/submodules/Filter/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Filter/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, ReactNode } from 'react';
 import {
   Filter,
   FilterVariant,
@@ -42,6 +42,7 @@ export type FilterCallback = (filter: FilterValues) => void;
 type Props = {
   orderableListCacheKey?: string;
   cacheApiPath?: string;
+  complementaryActions?: ReactNode;
 };
 
 const FilterSubmodule = (props: Props) => {

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -8,10 +8,7 @@ import {
   DialogTitle,
   DialogContent,
   IconButton,
-  Typography,
 } from '@mui/material';
-import ChevronLeft from '@mui/icons-material/ChevronLeft';
-import ChevronRight from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 import useDataProvider, { useQuery } from '@concepta/react-data-provider';
 import validator from '@rjsf/validator-ajv6';
@@ -19,6 +16,7 @@ import validator from '@rjsf/validator-ajv6';
 import { SchemaForm } from '../../../components/SchemaForm';
 import { CustomTextFieldWidget } from '../../../styles/CustomWidgets';
 import { FormSubmoduleProps } from '../types/Form';
+import TableRowControls from '../TableRowControls';
 
 const ModalFormSubmodule = (props: FormSubmoduleProps) => {
   const {
@@ -158,26 +156,20 @@ const ModalFormSubmodule = (props: FormSubmoduleProps) => {
             mt={4}
           >
             {viewMode !== 'creation' && (
-              <Box display="flex" alignItems="center" gap={2}>
-                <IconButton
-                  onClick={() => onPrevious(formData)}
-                  disabled={isLoading || (currentPage === 1 && viewIndex === 1)}
-                >
-                  <ChevronLeft sx={{ color: '#333' }} />
-                </IconButton>
-                <Typography>
-                  {isLoading ? '' : `Row ${viewIndex}/${rowsPerPage}`}
-                </Typography>
-                <IconButton
-                  onClick={() => onNext(formData)}
-                  disabled={
-                    isLoading ||
-                    (currentPage === pageCount && viewIndex === rowsPerPage)
-                  }
-                >
-                  <ChevronRight sx={{ color: '#333' }} />
-                </IconButton>
-              </Box>
+              <TableRowControls
+                isLoading={isLoading}
+                currentIndex={viewIndex}
+                rowsPerPage={rowsPerPage}
+                isPreviousDisabled={
+                  isLoading || (currentPage === 1 && viewIndex === 1)
+                }
+                isNextDisabled={
+                  isLoading ||
+                  (currentPage === pageCount && viewIndex === rowsPerPage)
+                }
+                onPrevious={() => onPrevious(formData)}
+                onNext={() => onNext(formData)}
+              />
             )}
             <Box
               display="flex"

--- a/packages/react-material-ui/src/components/submodules/Table/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Table/index.tsx
@@ -278,45 +278,41 @@ const TableSubmodule = (props: TableSubmoduleProps) => {
             <FilterSubmodule
               orderableListCacheKey={props.filterCacheKey}
               cacheApiPath={props.cacheApiPath}
+              complementaryActions={
+                <Box sx={{ display: 'flex' }}>
+                  {props.reordable !== false && (
+                    <Table.ColumnOrderable
+                      hasAllOption={props.hasAllOption}
+                      orderableListCacheKey={props.tableCacheKey}
+                      cacheApiPath={props.cacheApiPath}
+                    />
+                  )}
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="flex-end"
+                  >
+                    {props.additionalFilterRowContent}
+                    {!props.hideAddButton && (
+                      <Button
+                        variant="contained"
+                        onClick={props.onAddNew}
+                        startIcon={props.addButtonStartIcon || <AddIcon />}
+                        endIcon={props.addButtonEndIcon}
+                        sx={{
+                          textTransform: 'capitalize',
+                          textWrap: 'nowrap',
+                          marginLeft: 2,
+                        }}
+                      >
+                        {props.addButtonContent || 'Add new'}
+                      </Button>
+                    )}
+                  </Box>
+                </Box>
+              }
             />
           )}
-
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: { xs: 'space-between', lg: 'initial' },
-              mt: { xs: filters ? 2 : 0, lg: 0 },
-              ml: { xs: 0, lg: 2 },
-              width: { xs: '100%', lg: 'auto' },
-            }}
-          >
-            {props.reordable !== false && (
-              <Table.ColumnOrderable
-                hasAllOption={props.hasAllOption}
-                orderableListCacheKey={props.tableCacheKey}
-                cacheApiPath={props.cacheApiPath}
-              />
-            )}
-            <Box display="flex" alignItems="center" justifyContent="flex-end">
-              {props.additionalFilterRowContent}
-              {!props.hideAddButton && (
-                <Button
-                  variant="contained"
-                  onClick={props.onAddNew}
-                  startIcon={props.addButtonStartIcon || <AddIcon />}
-                  endIcon={props.addButtonEndIcon}
-                  sx={{
-                    textTransform: 'capitalize',
-                    textWrap: 'nowrap',
-                    marginLeft: 2,
-                  }}
-                >
-                  {props.addButtonContent || 'Add new'}
-                </Button>
-              )}
-            </Box>
-          </Box>
         </Box>
 
         <TableContainer sx={tableTheme.tableContainer}>

--- a/packages/react-material-ui/src/components/submodules/TableRowControls/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/TableRowControls/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Box, IconButton, Typography, Skeleton } from '@mui/material';
+import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import ChevronRight from '@mui/icons-material/ChevronRight';
+
+type Props = {
+  isLoading: boolean;
+  currentIndex: number;
+  rowsPerPage: number;
+  isPreviousDisabled: boolean;
+  isNextDisabled: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+};
+
+const TableRowControls = (props: Props) => {
+  const {
+    isLoading,
+    currentIndex,
+    rowsPerPage,
+    isPreviousDisabled,
+    isNextDisabled,
+    onPrevious,
+    onNext,
+  } = props;
+
+  return (
+    <Box display="flex" alignItems="center" gap={2}>
+      <IconButton onClick={onPrevious} disabled={isPreviousDisabled}>
+        <ChevronLeft sx={{ color: '#333' }} />
+      </IconButton>
+      <Typography sx={{ textTransform: 'uppercase', fontSize: '0.875rem' }}>
+        {isLoading ? (
+          <Skeleton
+            variant="text"
+            sx={{ fontSize: '0.875rem' }}
+            width={58}
+            height={22}
+          />
+        ) : (
+          `Row ${currentIndex}/${rowsPerPage}`
+        )}
+      </Typography>
+      <IconButton onClick={onNext} disabled={isNextDisabled}>
+        <ChevronRight sx={{ color: '#333' }} />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default TableRowControls;

--- a/packages/react-material-ui/src/components/submodules/types/Form.ts
+++ b/packages/react-material-ui/src/components/submodules/types/Form.ts
@@ -1,0 +1,48 @@
+import { PropsWithChildren, ReactNode } from 'react';
+import { RJSFSchema, UiSchema, CustomValidator } from '@rjsf/utils';
+import { FormProps } from '@rjsf/core';
+
+import { SchemaFormProps } from '../../../components/SchemaForm';
+
+export type Action = 'creation' | 'edit' | 'details' | null;
+
+export type FormSubmoduleProps = PropsWithChildren<
+  Omit<
+    SchemaFormProps,
+    | 'schema'
+    | 'uiSchema'
+    | 'validator'
+    | 'onSubmit'
+    | 'noHtml5Validate'
+    | 'showErrorList'
+    | 'formData'
+    | 'readonly'
+    | 'customValidate'
+  >
+> & {
+  isVisible: boolean;
+  queryResource: string;
+  title?: string;
+  formSchema?: RJSFSchema;
+  viewMode?: Action | null;
+  formUiSchema?: UiSchema;
+  formData?: Record<string, unknown> | null;
+  submitButtonTitle?: string;
+  cancelButtonTitle?: string;
+  hideCancelButton?: boolean;
+  customFooterContent?: ReactNode;
+  onClose?: () => void;
+  customValidate?: CustomValidator;
+  widgets?: FormProps['widgets'];
+  onSuccess?: (data: unknown) => void;
+  onError?: (error: unknown) => void;
+  onDeleteSuccess?: (data: unknown) => void;
+  onDeleteError?: (error: unknown) => void;
+  onPrevious?: (data: unknown) => void;
+  onNext?: (data: unknown) => void;
+  isLoading?: boolean;
+  viewIndex?: number;
+  rowsPerPage?: number;
+  currentPage?: number;
+  pageCount?: number;
+};

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -89,6 +89,7 @@ const CrudModule = (props: ModuleProps) => {
   const [drawerViewMode, setDrawerViewMode] = useState<Action>(null);
   const [selectedRow, setSelectedRow] = useState<SelectedRow>(null);
   const [currentViewIndex, setCurrentViewIndex] = useState<number>(0);
+  const [isFormVisible, setFormVisible] = useState<boolean>(false);
 
   const useTableReturn = useTable(props.resource, {
     callbacks: {
@@ -224,11 +225,13 @@ const CrudModule = (props: ModuleProps) => {
             setSelectedRow(payload.row);
             setDrawerViewMode(payload.action);
             setCurrentViewIndex(payload.index);
+            setFormVisible(true);
           }}
           onAddNew={() => {
             setSelectedRow(null);
             setDrawerViewMode('creation');
             setCurrentViewIndex(0);
+            setFormVisible(true);
           }}
           hideAddButton={!props.createFormProps}
           hideEditButton={!props.editFormProps || props.hideEditButton}
@@ -250,37 +253,26 @@ const CrudModule = (props: ModuleProps) => {
 
         {enhancedFormProps && (
           <FormComponent
+            isVisible={isFormVisible}
             title={props.title}
             queryResource={props.resource}
             viewMode={drawerViewMode}
             formData={selectedRow}
             onSuccess={(data) => {
               useTableReturn.refresh();
-
-              setSelectedRow(null);
-              setDrawerViewMode(null);
-              setCurrentViewIndex(0);
-
+              setFormVisible(false);
               if (formOnSuccess) {
                 formOnSuccess(data);
               }
             }}
             onDeleteSuccess={(data) => {
               useTableReturn.refresh();
-
-              setSelectedRow(null);
-              setDrawerViewMode(null);
-              setCurrentViewIndex(0);
-
+              setFormVisible(false);
               if (formOnDeleteSuccess) {
                 formOnDeleteSuccess(data);
               }
             }}
-            onClose={() => {
-              setSelectedRow(null);
-              setDrawerViewMode(null);
-              setCurrentViewIndex(0);
-            }}
+            onClose={() => setFormVisible(false)}
             onPrevious={() => changeCurrentFormData('previous')}
             onNext={() => changeCurrentFormData('next')}
             isLoading={isPending}


### PR DESCRIPTION
Changes on this PR:
- Adjustment on flickering buttons inside the CrudModule form
- Adjustment on Filter grid placement based on screen width
- Improvement on Form submodule prop path

Desktop
<img width="1440" alt="Screenshot 2024-08-30 at 11 41 56" src="https://github.com/user-attachments/assets/11c1058d-33ac-4b25-92af-efdfa9c887bc">

Tablet
<img width="1017" alt="Screenshot 2024-08-30 at 11 42 50" src="https://github.com/user-attachments/assets/837bbf30-6164-4173-bce9-10e1944097db">

Mobile
<img width="428" alt="Screenshot 2024-08-30 at 11 43 15" src="https://github.com/user-attachments/assets/381c7c0a-d47f-40bd-b9c8-8314e5c76cb7">
