### PR TITLE
Feature/filter module custom filters

### DIFF
--- a/packages/react-material-ui/src/components/Table/types.ts
+++ b/packages/react-material-ui/src/components/Table/types.ts
@@ -4,12 +4,16 @@ export type BasicType = string | number | boolean;
 
 export type SimpleFilter = Record<string, BasicType | BasicType[] | null>;
 
+export type CustomFilter = (data: unknown) => SimpleFilter;
+
 export type UpdateSimpleFilter = (
   simpleFilter: SimpleFilter | null,
   resetPage?: boolean,
 ) => void;
 
 export type Search = Record<string, any>;
+
+export type CustomSearch = (data: unknown) => Record<string, any>;
 
 export type HeaderProps = {
   disablePadding?: boolean;

--- a/packages/react-material-ui/src/components/submodules/Filter/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Filter/index.tsx
@@ -57,10 +57,15 @@ const FilterSubmodule = (props: Props) => {
     customSearch,
   } = useCrudRoot();
 
-  const customSearchData =
-    customSearch && useMemo(() => customSearch(filterValues), [filterValues]);
+  const customSearchData = useMemo(
+    () => customSearch?.(filterValues),
+    [filterValues],
+  );
 
-  const externalSearch = { ...customSearchData, ..._externalSearch };
+  const externalSearch = useMemo(
+    () => ({ ..._externalSearch, ...customSearchData }),
+    [customSearchData, _externalSearch],
+  );
 
   const hasExternalSearch =
     externalSearch &&
@@ -92,8 +97,8 @@ const FilterSubmodule = (props: Props) => {
     if (!hasExternalSearch) {
       updateSearch(null);
       const filterObj = {
-        ...customFilter?.(filterValues),
         ...reduceFilters(filterValues, 'simpleFilter'),
+        ...customFilter?.(filterValues),
       };
 
       updateSimpleFilter(filterObj, true);
@@ -101,8 +106,8 @@ const FilterSubmodule = (props: Props) => {
 
     if (hasExternalSearch) {
       const filterObj = {
-        ...customFilter?.(filterValues),
         ...reduceFilters(filterValues, 'search'),
+        ...customFilter?.(filterValues),
       };
 
       const combinedFilter = {
@@ -124,8 +129,8 @@ const FilterSubmodule = (props: Props) => {
 
       if (updateFilter) {
         const filterObj = {
-          ...customFilter?.(newFilterValues),
           ...reduceFilters(newFilterValues, 'simpleFilter'),
+          ...customFilter?.(newFilterValues),
         };
 
         updateSimpleFilter(filterObj, true);

--- a/packages/react-material-ui/src/components/submodules/Filter/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/Filter/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Filter,
   FilterVariant,
@@ -50,10 +50,17 @@ const FilterSubmodule = (props: Props) => {
     updateSearch,
     simpleFilter,
     updateSimpleFilter,
-    externalSearch,
+    externalSearch: _externalSearch,
     filterValues,
     setFilterValues,
+    customFilter,
+    customSearch,
   } = useCrudRoot();
+
+  const customSearchData =
+    customSearch && useMemo(() => customSearch(filterValues), [filterValues]);
+
+  const externalSearch = { ...customSearchData, ..._externalSearch };
 
   const hasExternalSearch =
     externalSearch &&
@@ -84,11 +91,22 @@ const FilterSubmodule = (props: Props) => {
   useEffect(() => {
     if (!hasExternalSearch) {
       updateSearch(null);
-      updateSimpleFilter(reduceFilters(filterValues, 'simpleFilter'), true);
+      const filterObj = {
+        ...customFilter?.(filterValues),
+        ...reduceFilters(filterValues, 'simpleFilter'),
+      };
+
+      updateSimpleFilter(filterObj, true);
     }
+
     if (hasExternalSearch) {
-      const combinedFilter = {
+      const filterObj = {
+        ...customFilter?.(filterValues),
         ...reduceFilters(filterValues, 'search'),
+      };
+
+      const combinedFilter = {
+        ...filterObj,
         ...externalSearch,
       };
 
@@ -105,10 +123,12 @@ const FilterSubmodule = (props: Props) => {
       const newFilterValues = { ...prv, [id]: value };
 
       if (updateFilter) {
-        updateSimpleFilter(
-          reduceFilters(newFilterValues, 'simpleFilter'),
-          true,
-        );
+        const filterObj = {
+          ...customFilter?.(newFilterValues),
+          ...reduceFilters(newFilterValues, 'simpleFilter'),
+        };
+
+        updateSimpleFilter(filterObj, true);
       }
       return newFilterValues;
     });

--- a/packages/react-material-ui/src/modules/crud/CrudRoot.tsx
+++ b/packages/react-material-ui/src/modules/crud/CrudRoot.tsx
@@ -8,6 +8,8 @@ type Props = Omit<CrudContextProps, 'filterValues' | 'setFilterValues'> & {
 
 const CrudRoot = (props: PropsWithChildren<Props>) => {
   const {
+    customFilter,
+    customSearch,
     filters,
     search,
     updateSearch,
@@ -44,6 +46,8 @@ const CrudRoot = (props: PropsWithChildren<Props>) => {
   return (
     <CrudContext.Provider
       value={{
+        customFilter,
+        customSearch,
         filters,
         search,
         updateSearch,

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -15,7 +15,11 @@ import TableSubmodule, {
 } from '../../components/submodules/Table';
 import DrawerFormSubmodule from '../../components/submodules/DrawerForm';
 import ModalFormSubmodule from '../../components/submodules/ModalForm';
-import { Search } from '../../components/Table/types';
+import {
+  Search,
+  CustomFilter,
+  CustomSearch,
+} from '../../components/Table/types';
 import CrudRoot from './CrudRoot';
 import { FilterDetails } from '../../components/submodules/Filter';
 import Breadcrumbs from '../../components/Breadcrumbs/Breadcrumbs';
@@ -38,6 +42,8 @@ interface TableProps {
   hasAllOption?: boolean;
   hideActionsColumn?: boolean;
   reordable?: boolean;
+  customFilter?: CustomFilter;
+  customSearch?: CustomSearch;
   filters?: FilterDetails[];
   paginationStyle?: PaginationStyle;
   onDeleteSuccess?: (data: unknown) => void;
@@ -187,13 +193,16 @@ const CrudModule = (props: ModuleProps) => {
   delete enhancedFormProps.onSuccess;
   delete enhancedFormProps.onDeleteSuccess;
 
-  const { filters, ...tableSubmoduleProps } = props.tableProps;
+  const { customFilter, customSearch, filters, ...tableSubmoduleProps } =
+    props.tableProps;
 
   const { isPending, tableQueryState } = useTableReturn;
 
   return (
     <CrudRoot
       filters={filters}
+      customFilter={customFilter}
+      customSearch={customSearch}
       search={useTableReturn.search}
       updateSearch={useTableReturn.updateSearch}
       simpleFilter={useTableReturn.simpleFilter}

--- a/packages/react-material-ui/src/modules/crud/useCrudRoot.tsx
+++ b/packages/react-material-ui/src/modules/crud/useCrudRoot.tsx
@@ -1,11 +1,23 @@
 import { createContext, useContext } from 'react';
 import { UseTableResult } from '../../components/Table/useTable';
-import { Search } from '../../components/Table/types';
+import { Search, SimpleFilter } from '../../components/Table/types';
 import { FilterDetails } from '../../components/submodules/Filter';
 
 export type FilterValues = Record<string, string | Date | null>;
 
 export type CrudContextProps = {
+  /**
+   *
+   * @param data - Object containing values of filter inputs
+   * @returns - Object for filtering Table data in a more intricate way
+   */
+  customFilter?: (data: FilterValues) => SimpleFilter | null;
+  /**
+   *
+   * @param data - Object containing values of filter inputs
+   * @returns - Object for filtering Table data in a more intricate way
+   */
+  customSearch?: (data: FilterValues) => Search | null;
   /**
    * Array of objects, where each contain details regarding filter inputs.
    */


### PR DESCRIPTION
Add customFilter and customSearch to filter modules and expose to crudModule

How to use it in crud module:

```jsx
const filters: ModuleProps["tableProps"]["filters"] = [
  {
    id: "fullName",
    label: "Username",
    operator: "contL",
    type: "text",
    columns: 3,
  },
  {
    id: "email",
    label: "Email",
    operator: "contL",
    type: "text",
    columns: 3,
  },
  {
    id: "user",
    label: "Name or Email",
    type: "text",
    columns: 3,
  },
];
```

``` jsx
tableProps: {
  filters: filters,
  customFilter: (data) => {
    const { fullName } = data;

    return {
      fullName: fullName ? `||$contL||${fullName}` : null,
    };
  },
  customSearch: (data) => {
    const { user } = data;
    if (user) {
      return {
        $or: [{ fullName: { contL: user } }, { email: { contL: user } }],
      };
    }
    return {};
  },
```