### PR TITLE
Feature/crud mod and navigation enhancements

### DIFF
--- a/packages/react-material-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/react-material-ui/src/components/Drawer/Drawer.tsx
@@ -8,7 +8,7 @@ import ChevronRight from '@mui/icons-material/ChevronRight';
 import { DrawerItem, DrawerItemProps } from './DrawerItem';
 import { Image } from '../Image';
 import Box from '@mui/material/Box';
-import { TextProps } from 'interfaces';
+import { TextProps } from '../../interfaces';
 import { SxProps, Theme } from '@mui/material/styles';
 
 /**

--- a/packages/react-material-ui/src/components/Drawer/DrawerItem.tsx
+++ b/packages/react-material-ui/src/components/Drawer/DrawerItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { DrawerButton, DrawerButtonProps } from './Styles';
 import Text from '../Text';
-import { TextProps } from 'interfaces';
+import { TextProps } from '../../interfaces';
 
 export const DEFAULT_DRAWER_TEXT_PROPS = {
   fontSize: 12,

--- a/packages/react-material-ui/src/components/Filter/Filter.tsx
+++ b/packages/react-material-ui/src/components/Filter/Filter.tsx
@@ -144,7 +144,7 @@ const renderComponent = (filter: FilterType) => {
           label={filter.label}
           isLoading={filter.isLoading}
           options={filter.options}
-          defaultValue={filter.defaultValue || ''}
+          defaultValue={filter.defaultValue ?? allOption.value}
           onChange={filter.onChange}
           value={filter.value}
           variant="outlined"

--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -109,6 +109,19 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
     ...widgets,
   };
 
+  const title = () => {
+    if (formSchema?.title) {
+      return formSchema.title;
+    }
+    if (viewMode === 'creation') {
+      return 'Add Data';
+    }
+    if (viewMode === 'edit') {
+      return 'Edit Data';
+    }
+    return 'View Data';
+  };
+
   return (
     <Drawer open={isVisible} anchor="right">
       <Box
@@ -120,11 +133,7 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
         ml={1}
       >
         <Typography variant="h5" sx={{ marginLeft: 3, fontSize: '20px' }}>
-          {viewMode === 'creation'
-            ? 'Add Data'
-            : viewMode === 'edit'
-            ? 'Edit Data'
-            : 'View Data'}
+          {title()}
         </Typography>
         <IconButton
           aria-label="close"

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -105,15 +105,22 @@ const ModalFormSubmodule = (props: FormSubmoduleProps) => {
     ...widgets,
   };
 
+  const title = () => {
+    if (formSchema?.title) {
+      return formSchema.title;
+    }
+    if (viewMode === 'creation') {
+      return 'Add Data';
+    }
+    if (viewMode === 'edit') {
+      return 'Edit Data';
+    }
+    return 'View Data';
+  };
+
   return (
     <Dialog open={isVisible} maxWidth="md" fullWidth onClose={onClose}>
-      <DialogTitle>
-        {viewMode === 'creation'
-          ? 'Add Data'
-          : viewMode === 'edit'
-          ? 'Edit Data'
-          : 'View Data'}
-      </DialogTitle>
+      <DialogTitle>{title()}</DialogTitle>
       <IconButton
         aria-label="close"
         onClick={onClose}

--- a/packages/react-material-ui/src/components/submodules/types/Form.ts
+++ b/packages/react-material-ui/src/components/submodules/types/Form.ts
@@ -22,7 +22,6 @@ export type FormSubmoduleProps = PropsWithChildren<
 > & {
   isVisible: boolean;
   queryResource: string;
-  title?: string;
   formSchema?: RJSFSchema;
   viewMode?: Action | null;
   formUiSchema?: UiSchema;

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -281,7 +281,6 @@ const CrudModule = (props: ModuleProps) => {
         {enhancedFormProps && (
           <FormComponent
             isVisible={isFormVisible}
-            title={titleName}
             queryResource={props.resource}
             viewMode={drawerViewMode}
             formData={selectedRow}

--- a/packages/react-navigation/src/components/Resource.tsx
+++ b/packages/react-navigation/src/components/Resource.tsx
@@ -1,11 +1,12 @@
 import React, { ReactNode } from 'react';
 import { Route } from 'react-router-dom';
 import { ModuleProps } from '@concepta/react-material-ui/dist/modules/crud';
+import { DrawerItemProps } from '@concepta/react-material-ui';
 
 type ResourceProps = {
   id: string;
   name: string;
-  icon: ReactNode;
+  icon: DrawerItemProps['icon'];
   showDrawerItem?: boolean;
   isUnprotected?: boolean;
   showAppBar?: boolean;


### PR DESCRIPTION
Fix #203 , #207 and #208 

closes #203 - Crud module - form - title customization
```jsx
const editSchema = {
  ...
  title: "Edit Molecule"
};

const createSchema = {
  ...
  title: "Add Molecule"
};

<CrudModule
...
createFormProps={{
  ...
  formSchema: createSchema,
}}
editFormProps={{
  ...
  formSchema: editSchema,
}}
/>
```
closes #207 
<img width="621" alt="Screenshot 2024-09-10 at 11 16 07" src="https://github.com/user-attachments/assets/560f3beb-18d7-47ef-96ce-40c35acdff48">


closes #208 - Resource props - Icon prop - accept ReactNode or Function with active param and returns ReactNode
```jsx
<Resource
      id="/molecule"
      name="Molecules"
      icon={(active) => (
        <DrawerMolecule
          color={
            active
              ? theme.palette.common.white
              : theme.palette.primary.contrastText
          }
        />
      )}
      page={<MoleculesScreen />}
    />
```
