### PR TITLE
Change logic for CrudModule form view index

### DIFF
--- a/packages/react-material-ui/src/components/submodules/TableRowControls/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/TableRowControls/index.tsx
@@ -23,7 +23,6 @@ const TableRowControls = (props: Props) => {
     currentPage,
     pageCount,
     currentIndex,
-    total,
     onPrevious,
     onNext,
   } = props;
@@ -48,7 +47,7 @@ const TableRowControls = (props: Props) => {
             height={22}
           />
         ) : (
-          `Row ${currentIndex}/${total}`
+          `Row ${currentIndex}/${rowsPerPage}`
         )}
       </Typography>
       <IconButton onClick={onNext} disabled={isNextDisabled}>

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -305,12 +305,9 @@ const CrudModule = (props: ModuleProps) => {
             onNext={() => changeCurrentFormData('next')}
             isLoading={isPending}
             tableRowsProps={{
-              currentIndex:
-                (tableQueryState.page - 1) * tableQueryState.rowsPerPage +
-                currentViewIndex +
-                1,
+              currentIndex: currentViewIndex + 1,
               viewIndex: currentViewIndex + 1,
-              rowsPerPage: tableQueryState.rowsPerPage,
+              rowsPerPage: useTableReturn?.data?.length || 0,
               currentPage: tableQueryState.page,
               pageCount: useTableReturn.pageCount,
               total: useTableReturn.total,


### PR DESCRIPTION
Previously, the table row control inside the CrudModule form was based on the `rowsPerPage` attribute from `useTable`. However, when a filter was active and the table rows length changed, the row control still rendered the previous value. For example, if the `rowsPerPage` number was 10 but the table displayed only one row when filtered, the control displayed `Row n/10`.

To change this behavior and display the correct number of rows, the control number is now based on the length of the `data` array present on the `useTable` returned object.