### PR TITLE
Add Cancel button to Crud edit form

### DIFF
--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -141,12 +141,13 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
         )}
         <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
           {props.customFooterContent}
-          {viewMode === 'creation' && !props.hideCancelButton && (
-            <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
-              {cancelButtonTitle || 'Cancel'}
-            </Button>
-          )}
-          {viewMode === 'edit' && !props.hideCancelButton && (
+          {(viewMode === 'creation' || viewMode === 'edit') &&
+            !props.hideCancelButton && (
+              <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
+                {cancelButtonTitle || 'Cancel'}
+              </Button>
+            )}
+          {viewMode === 'edit' && props.isDeleteButtonVisible && (
             <Button
               variant="contained"
               color="error"

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -190,12 +190,13 @@ const ModalFormSubmodule = (props: FormSubmoduleProps) => {
               gap={2}
             >
               {props.customFooterContent}
-              {viewMode === 'creation' && !props.hideCancelButton && (
-                <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
-                  {cancelButtonTitle || 'Cancel'}
-                </Button>
-              )}
-              {viewMode === 'edit' && !props.hideCancelButton && (
+              {(viewMode === 'creation' || viewMode === 'edit') &&
+                !props.hideCancelButton && (
+                  <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
+                    {cancelButtonTitle || 'Cancel'}
+                  </Button>
+                )}
+              {viewMode === 'edit' && props.isDeleteButtonVisible && (
                 <Button
                   variant="contained"
                   color="error"

--- a/packages/react-material-ui/src/components/submodules/types/Form.ts
+++ b/packages/react-material-ui/src/components/submodules/types/Form.ts
@@ -41,6 +41,7 @@ export type FormSubmoduleProps = PropsWithChildren<
   submitButtonTitle?: string;
   cancelButtonTitle?: string;
   hideCancelButton?: boolean;
+  isDeleteButtonVisible?: boolean;
   customFooterContent?: ReactNode;
   onClose?: () => void;
   customValidate?: CustomValidator;


### PR DESCRIPTION
The Cancel button should appear also in the Edit form. To achieve this goal, the Cancel button is now visible by default and the Delete button is visible only if the `isDeleteButtonVisible` form has a truthful value.