### PR TITLE
Feat/crud module enhancements

### DIFF
--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import type { IChangeEvent } from '@rjsf/core';
 import {
   Box,
@@ -47,6 +47,10 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
 
   const [fieldValues, setFieldValues] =
     useState<FormSubmoduleProps['formData']>(formData);
+
+  useEffect(() => {
+    setFieldValues(formData);
+  }, [formData]);
 
   const { post, patch, del } = useDataProvider();
 
@@ -135,8 +139,8 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
           <TableRowControls
             {...tableRowsProps}
             isLoading={isLoading}
-            onPrevious={() => onPrevious()}
-            onNext={() => onNext()}
+            onPrevious={onPrevious}
+            onNext={onNext}
           />
         )}
         <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
@@ -250,30 +254,43 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
         }}
         className="Rockets-FormDrawer-SchemaWrapper"
       >
-        <SchemaForm.Form
-          schema={{
-            ...formSchema,
-            required: formSchema?.required || [],
-            properties: formSchema?.properties || {},
-            title: '',
-          }}
-          uiSchema={{
-            ...formUiSchema,
-            'ui:submitButtonOptions': { norender: true },
-          }}
-          noHtml5Validate={true}
-          showErrorList={false}
-          formData={fieldValues}
-          widgets={_widgets}
-          customValidate={customValidate}
-          readonly={viewMode === 'details'}
-          onChange={handleFieldChange}
-          onSubmit={handleFormSubmit}
-          {...otherProps}
-        >
-          {children}
-          {actionButtons}
-        </SchemaForm.Form>
+        {isLoading ? (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              my: 10,
+            }}
+          >
+            <CircularProgress />
+          </Box>
+        ) : (
+          <SchemaForm.Form
+            schema={{
+              ...formSchema,
+              required: formSchema?.required || [],
+              properties: formSchema?.properties || {},
+              title: '',
+            }}
+            uiSchema={{
+              ...formUiSchema,
+              'ui:submitButtonOptions': { norender: true },
+            }}
+            noHtml5Validate={true}
+            showErrorList={false}
+            formData={fieldValues}
+            widgets={_widgets}
+            customValidate={customValidate}
+            readonly={viewMode === 'details'}
+            onChange={handleFieldChange}
+            onSubmit={handleFormSubmit}
+            {...otherProps}
+          >
+            {children}
+            {actionButtons}
+          </SchemaForm.Form>
+        )}
       </Box>
     </Drawer>
   );

--- a/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/DrawerForm/index.tsx
@@ -140,7 +140,10 @@ const DrawerFormSubmodule = (props: FormSubmoduleProps) => {
           />
         )}
         <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
-          {props.customFooterContent}
+          {props.customFooterContent &&
+            (typeof props.customFooterContent === 'function'
+              ? props.customFooterContent(formData)
+              : props.customFooterContent)}
           {viewMode === 'creation' && !props.hideCancelButton && (
             <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
               {cancelButtonTitle || 'Cancel'}

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { IChangeEvent } from '@rjsf/core';
 import {
   Box,
@@ -47,6 +47,10 @@ const ModalFormSubmodule = (props: FormSubmoduleProps) => {
 
   const [fieldValues, setFieldValues] =
     useState<FormSubmoduleProps['formData']>(formData);
+
+  useEffect(() => {
+    setFieldValues(formData);
+  }, [formData]);
 
   const { post, patch, del } = useDataProvider();
 
@@ -145,97 +149,110 @@ const ModalFormSubmodule = (props: FormSubmoduleProps) => {
         <CloseIcon />
       </IconButton>
       <DialogContent>
-        <SchemaForm.Form
-          schema={{
-            ...formSchema,
-            required: formSchema?.required || [],
-            properties: formSchema?.properties || {},
-            title: '',
-          }}
-          uiSchema={formUiSchema}
-          validator={validator}
-          onSubmit={handleFormSubmit}
-          noHtml5Validate={true}
-          showErrorList={false}
-          formData={fieldValues}
-          widgets={_widgets}
-          onChange={handleFieldChange}
-          customValidate={customValidate}
-          readonly={viewMode === 'details'}
-          {...otherProps}
-        >
-          {children}
+        {isLoading ? (
           <Box
-            display="flex"
-            flexDirection="row"
-            alignItems="center"
-            justifyContent={
-              viewMode === 'creation' ? 'flex-end' : 'space-between'
-            }
-            mt={4}
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              my: 10,
+            }}
           >
-            {viewMode !== 'creation' && (
-              <TableRowControls
-                {...tableRowsProps}
-                isLoading={isLoading}
-                onPrevious={() => onPrevious()}
-                onNext={() => onNext()}
-              />
-            )}
+            <CircularProgress />
+          </Box>
+        ) : (
+          <SchemaForm.Form
+            schema={{
+              ...formSchema,
+              required: formSchema?.required || [],
+              properties: formSchema?.properties || {},
+              title: '',
+            }}
+            uiSchema={formUiSchema}
+            validator={validator}
+            onSubmit={handleFormSubmit}
+            noHtml5Validate={true}
+            showErrorList={false}
+            formData={fieldValues}
+            widgets={_widgets}
+            onChange={handleFieldChange}
+            customValidate={customValidate}
+            readonly={viewMode === 'details'}
+            {...otherProps}
+          >
+            {children}
             <Box
               display="flex"
               flexDirection="row"
               alignItems="center"
-              mt={2}
-              gap={2}
+              justifyContent={
+                viewMode === 'creation' ? 'flex-end' : 'space-between'
+              }
+              mt={4}
             >
-              {props.customFooterContent &&
-                (typeof props.customFooterContent === 'function'
-                  ? props.customFooterContent(formData)
-                  : props.customFooterContent)}
-              {viewMode === 'creation' && !props.hideCancelButton && (
-                <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
-                  {cancelButtonTitle || 'Cancel'}
-                </Button>
+              {viewMode !== 'creation' && (
+                <TableRowControls
+                  {...tableRowsProps}
+                  isLoading={isLoading}
+                  onPrevious={onPrevious}
+                  onNext={onNext}
+                />
               )}
-              {viewMode === 'edit' && !props.hideCancelButton && (
-                <Button
-                  variant="contained"
-                  color="error"
-                  onClick={() => deleteItem(formData)}
-                  sx={{ flex: 1 }}
-                >
-                  {isLoadingDelete ? (
-                    <CircularProgress sx={{ color: 'white' }} size={24} />
-                  ) : (
-                    cancelButtonTitle || 'Delete'
-                  )}
-                </Button>
-              )}
-              {viewMode === 'details' && !props.hideCancelButton && (
-                <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
-                  {cancelButtonTitle || 'Close'}
-                </Button>
-              )}
-              {viewMode !== 'details' && (
-                <Button
-                  type="submit"
-                  variant="contained"
-                  disabled={
-                    isLoadingCreation || isLoadingEdit || isLoadingDelete
-                  }
-                  sx={{ flex: 1 }}
-                >
-                  {isLoadingCreation || isLoadingEdit ? (
-                    <CircularProgress sx={{ color: 'white' }} size={24} />
-                  ) : (
-                    submitButtonTitle || 'Save'
-                  )}
-                </Button>
-              )}
+              <Box
+                display="flex"
+                flexDirection="row"
+                alignItems="center"
+                mt={2}
+                gap={2}
+              >
+                {props.customFooterContent &&
+                  (typeof props.customFooterContent === 'function'
+                    ? props.customFooterContent(formData)
+                    : props.customFooterContent)}
+                {viewMode === 'creation' && !props.hideCancelButton && (
+                  <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
+                    {cancelButtonTitle || 'Cancel'}
+                  </Button>
+                )}
+                {viewMode === 'edit' && !props.hideCancelButton && (
+                  <Button
+                    variant="contained"
+                    color="error"
+                    onClick={() => deleteItem(formData)}
+                    sx={{ flex: 1 }}
+                  >
+                    {isLoadingDelete ? (
+                      <CircularProgress sx={{ color: 'white' }} size={24} />
+                    ) : (
+                      cancelButtonTitle || 'Delete'
+                    )}
+                  </Button>
+                )}
+                {viewMode === 'details' && !props.hideCancelButton && (
+                  <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
+                    {cancelButtonTitle || 'Close'}
+                  </Button>
+                )}
+                {viewMode !== 'details' && (
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    disabled={
+                      isLoadingCreation || isLoadingEdit || isLoadingDelete
+                    }
+                    sx={{ flex: 1 }}
+                  >
+                    {isLoadingCreation || isLoadingEdit ? (
+                      <CircularProgress sx={{ color: 'white' }} size={24} />
+                    ) : (
+                      submitButtonTitle || 'Save'
+                    )}
+                  </Button>
+                )}
+              </Box>
             </Box>
-          </Box>
-        </SchemaForm.Form>
+          </SchemaForm.Form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
+++ b/packages/react-material-ui/src/components/submodules/ModalForm/index.tsx
@@ -189,7 +189,10 @@ const ModalFormSubmodule = (props: FormSubmoduleProps) => {
               mt={2}
               gap={2}
             >
-              {props.customFooterContent}
+              {props.customFooterContent &&
+                (typeof props.customFooterContent === 'function'
+                  ? props.customFooterContent(formData)
+                  : props.customFooterContent)}
               {viewMode === 'creation' && !props.hideCancelButton && (
                 <Button variant="outlined" onClick={onClose} sx={{ flex: 1 }}>
                   {cancelButtonTitle || 'Cancel'}

--- a/packages/react-material-ui/src/components/submodules/types/Form.ts
+++ b/packages/react-material-ui/src/components/submodules/types/Form.ts
@@ -24,7 +24,6 @@ export type FormSubmoduleProps = PropsWithChildren<
     | 'schema'
     | 'uiSchema'
     | 'validator'
-    | 'onSubmit'
     | 'noHtml5Validate'
     | 'showErrorList'
     | 'formData'

--- a/packages/react-material-ui/src/components/submodules/types/Form.ts
+++ b/packages/react-material-ui/src/components/submodules/types/Form.ts
@@ -7,7 +7,7 @@ import { SchemaFormProps } from '../../../components/SchemaForm';
 
 export type Action = 'creation' | 'edit' | 'details' | null;
 
-type FormData = Record<string, unknown> | null;
+export type FormData = Record<string, unknown> | null;
 
 export type TableRowsProps = {
   currentIndex: number;
@@ -41,7 +41,7 @@ export type FormSubmoduleProps = PropsWithChildren<
   submitButtonTitle?: string;
   cancelButtonTitle?: string;
   hideCancelButton?: boolean;
-  customFooterContent?: ReactNode;
+  customFooterContent?: ReactNode | ((data: FormData) => ReactNode);
   onClose?: () => void;
   customValidate?: CustomValidator;
   widgets?: FormProps['widgets'];

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -30,6 +30,8 @@ import {
   FilterValues,
 } from './useCrudRoot';
 
+import { useCrudControls, ControlsActionEnum } from './useCrudControls';
+
 type Action = 'creation' | 'edit' | 'details' | null;
 
 type SelectedRow = Record<string, unknown> | null;
@@ -114,8 +116,45 @@ const CrudModule = (props: ModuleProps) => {
     navigate: props.navigate,
   });
 
-  const { data, tableQueryState, setTableQueryState, pageCount, isPending } =
-    useTableReturn;
+  // Assign functions and data to CrudControls
+  const {
+    data,
+    tableQueryState,
+    setTableQueryState,
+    pageCount,
+    isPending,
+    refresh,
+  } = useTableReturn;
+  const { refreshTable, dispatch } = useCrudControls();
+
+  useEffect(() => {
+    if (!refreshTable && refresh && dispatch) {
+      dispatch({
+        type: ControlsActionEnum.ASSIGN_REFRESH_TABLE,
+        payload: refresh,
+      });
+    }
+  }, [refresh]);
+
+  useEffect(() => {
+    if (dispatch) {
+      dispatch({ type: ControlsActionEnum.ASSIGN_TABLE_DATA, payload: data });
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (dispatch) {
+      dispatch({
+        type: ControlsActionEnum.ASSIGN_IS_FORM_VISIBLE,
+        payload: isFormVisible,
+      });
+      dispatch({
+        type: ControlsActionEnum.ASSIGN_SET_FORM_VISIBLE,
+        payload: setFormVisible,
+      });
+    }
+  }, [isFormVisible]);
+  // End of CrudControls assignment
 
   const changeCurrentFormData = (direction: 'previous' | 'next') => {
     const isPrevious = direction === 'previous';

--- a/packages/react-material-ui/src/modules/crud/index.tsx
+++ b/packages/react-material-ui/src/modules/crud/index.tsx
@@ -55,6 +55,7 @@ type FormProps = Pick<
   FormSubmoduleProps,
   | 'formSchema'
   | 'formUiSchema'
+  | 'onSubmit'
   | 'submitButtonTitle'
   | 'cancelButtonTitle'
   | 'hideCancelButton'

--- a/packages/react-material-ui/src/modules/crud/useCrudControls.tsx
+++ b/packages/react-material-ui/src/modules/crud/useCrudControls.tsx
@@ -1,0 +1,88 @@
+import React, {
+  createContext,
+  useContext,
+  PropsWithChildren,
+  useReducer,
+} from 'react';
+
+export enum ControlsActionEnum {
+  ASSIGN_REFRESH_TABLE = 'ASSIGN_REFRESH_TABLE',
+  ASSIGN_IS_FORM_VISIBLE = 'ASSIGN_IS_FORM_VISIBLE',
+  ASSIGN_SET_FORM_VISIBLE = 'ASSIGN_SET_FORM_VISIBLE',
+  ASSIGN_TABLE_DATA = 'ASSIGN_TABLE_DATA',
+}
+
+interface ControlsState {
+  refreshTable?: () => void;
+  isFormVisible?: boolean;
+  setFormVisible?: React.Dispatch<React.SetStateAction<boolean>>;
+  tableData?: unknown[];
+}
+
+type CrudControlsProps = ControlsState & {
+  dispatch?: React.Dispatch<ControlsAction>;
+};
+
+interface RefreshTableAction {
+  type: ControlsActionEnum.ASSIGN_REFRESH_TABLE;
+  payload: () => void;
+}
+interface IsFormVisibleAction {
+  type: ControlsActionEnum.ASSIGN_IS_FORM_VISIBLE;
+  payload: boolean;
+}
+interface SetFormVisibleAction {
+  type: ControlsActionEnum.ASSIGN_SET_FORM_VISIBLE;
+  payload: React.Dispatch<React.SetStateAction<boolean>>;
+}
+interface TableDataAction {
+  type: ControlsActionEnum.ASSIGN_TABLE_DATA;
+  payload: unknown[];
+}
+
+type ControlsAction =
+  | RefreshTableAction
+  | IsFormVisibleAction
+  | SetFormVisibleAction
+  | TableDataAction;
+
+export const CrudControls = createContext<CrudControlsProps>({});
+
+export const useCrudControls = () => useContext(CrudControls);
+
+const reducer = (state: ControlsState, action: ControlsAction) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case ControlsActionEnum.ASSIGN_REFRESH_TABLE:
+      return { ...state, refreshTable: payload };
+    case ControlsActionEnum.ASSIGN_IS_FORM_VISIBLE:
+      return { ...state, isFormVisible: payload };
+    case ControlsActionEnum.ASSIGN_SET_FORM_VISIBLE:
+      return { ...state, setFormVisible: payload };
+    case ControlsActionEnum.ASSIGN_TABLE_DATA:
+      return { ...state, tableData: payload };
+    default:
+      return state;
+  }
+};
+
+export const CrudControlsProvider: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, {});
+
+  return (
+    <CrudControls.Provider
+      value={{
+        refreshTable: state.refreshTable,
+        isFormVisible: state.isFormVisible,
+        setFormVisible: state.setFormVisible,
+        tableData: state.tableData,
+        dispatch,
+      }}
+    >
+      {children}
+    </CrudControls.Provider>
+  );
+};


### PR DESCRIPTION
## Feats
CustomFooterContent
- Change customFooterContent in FormProps to also accept a function with FormData param that returns a ReactNode.

FormProps - onSubmit
- Add onSubmit to FormProps to override the CrudModule's onSubmit function

Add CrudControls Context Provider to allow user to access the following props from outside the Crud Module:
- refreshTable
- isFormVisible
- setFormVisible
- tableData

Fix TableRowControls
- Update data on table row next or previous click

Fix data flickering on table page change
- Show loading indicaton in forms during page change

## How to use CrudControls
### Import it at your component
```jsx
import {
  CrudControlsProvider,
  useCrudControls,
} from "@concepta/react-material-ui/dist/modules/crud/useCrudControls";

const UsersScreen = () => {
  const { isFormVisible, setFormVisible, refreshTable, tableData } = useCrudControls();

...
}

```

### Wrap your component with the CrudControlsProvider
```jsx
const UsersWithControls = () => {
  return (
    <CrudControlsProvider>
      <UsersScreen />
    </CrudControlsProvider>
  );
};

export default UsersWithControls;
```