### PR TITLE
feat: adjust initial route to prevent redirect on refresh

### DIFF
--- a/packages/react-navigation/src/components/Router.tsx
+++ b/packages/react-navigation/src/components/Router.tsx
@@ -28,21 +28,19 @@ const Router = ({
     {
       path: '/',
       element: rootElement ? (
-        React.cloneElement(
-          rootElement,
-          {},
-          <>
-            <Outlet />
-            {initialRoute && <Navigate to={initialRoute} replace />}
-          </>,
-        )
+        React.cloneElement(rootElement, {}, <Outlet />)
       ) : (
-        <div>
-          Home test no root
-          <Outlet />
-        </div>
+        <Outlet />
       ),
       children: [
+        ...(initialRoute
+          ? [
+              {
+                path: '/',
+                element: <Navigate to={initialRoute} replace />,
+              },
+            ]
+          : []),
         {
           path: '*',
           element: childRoutes,


### PR DESCRIPTION
Adjustments to initial route so the user is not redirect on page refresh.

How to use the new format:

```jsx
import { Router, Resource, ChildRoutes } from "@concepta/react-navigation";

<Router
    rootElement={<AdminProvider />}
    childRoutes={<Routes />}
    initialRoute="/molecule"
/>
```