### PR TITLE
Add handler for drawer state on ChildRoutes component

### DIFF
--- a/packages/react-navigation/src/components/AppBarContainer.tsx
+++ b/packages/react-navigation/src/components/AppBarContainer.tsx
@@ -49,7 +49,7 @@ export default function AppBarContainer({
       />
       <AppBar.Main>
         <AppBar.Nav
-          text={(user as any)?.username || ''}
+          text={(user as { username: string })?.username || ''}
           headerMenuOptions={(handleClose) => (
             <MenuItem onClick={() => onLogoutClick(handleClose)}>
               Sign Out

--- a/packages/react-navigation/src/components/ChildRoutes.tsx
+++ b/packages/react-navigation/src/components/ChildRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { Children, ReactElement, ReactNode } from 'react';
+import React, { Children, ReactElement, ReactNode, useState } from 'react';
 import { useRoutes } from 'react-router-dom';
 import {
   DrawerItemProps,
@@ -45,6 +45,10 @@ const ChildRoutes = ({
   renderForgotPassword,
   renderResetPassword,
 }: ChildRoutesProps) => {
+  const [isDrawerCollapsed, setDrawerCollapsed] = useState(
+    Boolean(drawerProps.collapsed),
+  );
+
   const items = Children.map(children, (child) => {
     // This validation is needed so `showDrawerItem`
     // can be `true` by default
@@ -126,7 +130,16 @@ const ChildRoutes = ({
           module={child.props.module}
           page={child.props.page}
           items={items}
-          drawerProps={drawerProps}
+          drawerProps={{
+            ...drawerProps,
+            collapsed: isDrawerCollapsed,
+            onCollapsedChange: (collapsed) => {
+              setDrawerCollapsed(collapsed);
+              if (drawerProps.onCollapsedChange) {
+                drawerProps.onCollapsedChange(collapsed);
+              }
+            },
+          }}
           navbarProps={navbarProps}
         />
       ),


### PR DESCRIPTION
### Relates to #255 

The issue describes that the `AppBar` drawer `collapsed` state is being reset on every page change and the drawer should be rendered oustide of the route hierarchy. However, the `AppBar` visibility can be managed from inside the child routes, making it difficult to implement rendering outside of those routes.

This PR presents a solution by managing state from inside the `ChildRoutes`, so that every route change gets the correct state from the previous one.