### PR TITLE
Adjust user id on storage settings hook

### DIFF
--- a/packages/react-material-ui/src/hooks/useSettingsStorage.ts
+++ b/packages/react-material-ui/src/hooks/useSettingsStorage.ts
@@ -270,7 +270,7 @@ export const useSettingsStorage = (props: Props) => {
     if (props.cacheApiPath) {
       fetchOrCreateCache();
     }
-  }, []);
+  }, [auth?.user]);
 
   return { settings, updateSettings, clearSettings };
 };


### PR DESCRIPTION
Adjust user id on storage settings hook. The reason for the change is that in some cases the user id was not set in the first render, resulting on the cache list not being set on the filters.