### PR TITLE
feat: allow data provider to pass responseType to axios client

### DIFF
--- a/packages/react-data-provider/src/axiosClient.ts
+++ b/packages/react-data-provider/src/axiosClient.ts
@@ -33,6 +33,7 @@ const axiosClient: HttpClient = {
         params: configs.queryParams,
         signal: configs.signal,
         ...('body' in configs && { data: configs.body }),
+        responseType: configs?.responseType,
       })
       .then((response) => {
         const { config, data, headers, status } = response;

--- a/packages/react-data-provider/src/interfaces/index.ts
+++ b/packages/react-data-provider/src/interfaces/index.ts
@@ -1,10 +1,11 @@
-import { AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig, ResponseType } from 'axios';
 
 export interface RequestParams {
   uri: string;
   method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'PATCH';
   headers?: Record<string, string>;
   queryParams?: Record<string, string | string[] | number | undefined>;
+  responseType?: ResponseType;
   signal?: AbortSignal;
 }
 


### PR DESCRIPTION
### About

This PR allows data provider to pass `responseType` to axios client. This way we can make requests for different responses (e.g. when we're trying to download a file that responds with a blob)